### PR TITLE
fix(deb): auto-restart service on upgrade + add build_info metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ When `metrics.enabled: true`, valerter exposes a `/metrics` endpoint on the conf
 | `valerter_last_query_timestamp` | Gauge | `rule_name` | Unix timestamp of last successful query chunk |
 | `valerter_victorialogs_up` | Gauge | `rule_name` | VictoriaLogs connection status (1=up, 0=down) |
 | `valerter_uptime_seconds` | Gauge | - | Time since valerter started |
+| `valerter_build_info` | Gauge | `version` | Build information (always 1) |
 | `valerter_query_duration_seconds` | Histogram | `rule_name` | VictoriaLogs query latency (time to first chunk) |
 
 ### Example Prometheus Alerts

--- a/debian/postinst
+++ b/debian/postinst
@@ -24,6 +24,10 @@ case "$1" in
         # Reload systemd (if available)
         if command -v systemctl >/dev/null 2>&1; then
             systemctl daemon-reload || true
+            # Restart service on upgrade (not on fresh install)
+            if [ -n "$2" ] && systemctl is-active --quiet valerter; then
+                systemctl restart valerter || true
+            fi
         fi
         ;;
 esac

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,6 +274,9 @@ async fn run(runtime_config: valerter::config::RuntimeConfig) -> Result<()> {
         None
     };
 
+    // Set build_info metric with version label (always 1)
+    metrics::gauge!("valerter_build_info", "version" => env!("CARGO_PKG_VERSION")).set(1.0);
+
     // Start uptime metric updater (updates every 15 seconds)
     let uptime_cancel = cancel.clone();
     tokio::spawn(async move {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -83,6 +83,10 @@ pub fn register_metric_descriptions() {
         "valerter_uptime_seconds",
         "Time in seconds since valerter started"
     );
+    describe_gauge!(
+        "valerter_build_info",
+        "Build information with version label (always 1)"
+    );
 
     // Histograms
     describe_histogram!(


### PR DESCRIPTION
## Summary
- **postinst**: Auto-restart valerter service on .deb upgrade (only if service was already running)
- **build_info metric**: Add `valerter_build_info{version="x.y.z"} 1` gauge for version tracking

## Changes
- `debian/postinst`: Restart service after upgrade if it was active
- `src/metrics.rs`: Add build_info metric description
- `src/main.rs`: Set build_info gauge at startup with version from Cargo.toml
- `README.md`: Document new metric

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes
- [x] CI checks