### PR TITLE
feat(notify): Telegram Bot notifier — v1.1.0 (closes #22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Local config (secrets)
 config/prod/
+config/prod-*/
 config/test/
 config/minimal/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.0] - 2026-04-14
+## [1.1.0] - 2026-04-15
 
 ### Added
 - **Telegram notifier** (issue #22) — native `type: telegram` notifier using the
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   HTTP call per `chat_id`), HTML `parse_mode` by default, 429 `Retry-After`
   handling, automatic codepoint-safe truncation at Telegram's 4096 character
   limit, and a new `valerter_alerts_truncated_total` Prometheus counter.
+
+### Known Limitations
+- Templates define a single `body` field that is shared across all notifiers. If
+  you write a Markdown-flavored body (e.g. `**bold**`, triple-backtick fences)
+  for Mattermost, Telegram will render those markers literally because it is
+  configured with `parse_mode: HTML`. Workaround: override `body_template` on
+  the Telegram notifier with HTML-friendly Jinja, for example
+  `body_template: "<b>{{ title|e }}</b>\n<pre>{{ body|e }}</pre>"`. A proper
+  render-pipeline-per-notifier abstraction is planned for 1.2.
 
 ## [1.0.0] - 2026-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-14
+
+### Added
+- **Telegram notifier** (issue #22) — native `type: telegram` notifier using the
+  Bot API `sendMessage` endpoint. Supports multi-chat delivery (one sequential
+  HTTP call per `chat_id`), HTML `parse_mode` by default, 429 `Retry-After`
+  handling, automatic codepoint-safe truncation at Telegram's 4096 character
+  limit, and a new `valerter_alerts_truncated_total` Prometheus counter.
+
 ## [1.0.0] - 2026-04-14
 
 Promote `1.0.0-rc.5` to stable. No functional changes.
@@ -143,7 +152,8 @@ Promote `1.0.0-rc.5` to stable. No functional changes.
 - Debian package (.deb) and tarball releases
 - systemd service integration
 
-[Unreleased]: https://github.com/fxthiry/valerter/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/fxthiry/valerter/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/fxthiry/valerter/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/fxthiry/valerter/compare/v1.0.0-rc.5...v1.0.0
 [1.0.0-rc.5]: https://github.com/fxthiry/valerter/compare/v1.0.0-rc.4...v1.0.0-rc.5
 [1.0.0-rc.4]: https://github.com/fxthiry/valerter/compare/v1.0.0-rc.3...v1.0.0-rc.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "valerter"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "valerter"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "Real-time log alerting for VictoriaLogs"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See [Cisco Switches example](examples/cisco-switches/) for a complete implementa
 
 ## Features
 
-- **Multi-channel notifications** — Webhook (PagerDuty, Slack, Discord), Email SMTP, Mattermost
+- **Multi-channel notifications** — Webhook (PagerDuty, Slack, Discord), Email SMTP, Mattermost, Telegram
 - **Full log context** — Alerts include the actual log line and extracted fields
 - **Intelligent throttling** — Avoid alert spam with per-key rate limiting
 - **Real-time alerting** — Less than 5 seconds from log event to notification
@@ -126,7 +126,7 @@ rules:
 
 - **[Getting Started](docs/getting-started.md)** — Installation and first setup
 - **[Configuration](docs/configuration.md)** — Full configuration reference
-- **[Notifiers](docs/notifiers.md)** — Webhook, Email, Mattermost setup
+- **[Notifiers](docs/notifiers.md)** — Webhook, Email, Mattermost, Telegram setup
 - **[Metrics](docs/metrics.md)** — Prometheus metrics and alerting rules
 - **[Performance](docs/performance.md)** — Benchmarks and capacity planning
 - **[Architecture](docs/architecture.md)** — How Valerter works

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -225,6 +225,32 @@ notifiers:
   #     <p>{{ body }}</p>
   #   # body_template_file: /etc/valerter/email-template.html  # Or: external file
 
+  # ── Telegram (Bot API) ─────────────────────────────────────────────────────
+  # Send alerts to one or more Telegram chats via the Bot API.
+  #
+  # Required: bot_token, chat_ids (non-empty)
+  # Optional: parse_mode (default: HTML), disable_notification,
+  #           disable_web_page_preview, body_template
+  #
+  # The endpoint URL is built internally and never logged (contains the token).
+  # Each chat_id triggers one sequential HTTP call; a 429 response honors
+  # Telegram's Retry-After header before retrying.
+  # Message text is truncated at 4096 Unicode codepoints (Telegram hard limit)
+  # and the event is counted in valerter_alerts_truncated_total.
+
+  # telegram-alerts:
+  #   type: telegram
+  #   bot_token: "${TELEGRAM_BOT_TOKEN}"
+  #   chat_ids:
+  #     - "-100123456789"
+  #     - "-100987654321"
+  #   parse_mode: HTML                       # Default: HTML (also: MarkdownV2)
+  #   disable_notification: false            # Default: not set (Telegram default = false)
+  #   disable_web_page_preview: true         # Default: not set
+  #   body_template: |                       # Optional; default: "<b>{{ title|e }}</b>\n{{ body|e }}"
+  #     <b>{{ title|e }}</b>
+  #     {{ body|e }}
+
 
 # ┌────────────────────────────────────────────────────────────────────────────┐
 # │ RULES                                                            [REQUIRED]│

--- a/docs/notifiers.md
+++ b/docs/notifiers.md
@@ -9,6 +9,7 @@ Valerter supports multiple notification channels. Configure them in the `notifie
 | `webhook` | Generic HTTP endpoint | PagerDuty, Slack, Discord, custom APIs |
 | `email` | SMTP email | Ops teams, compliance, audit trails |
 | `mattermost` | Mattermost incoming webhook | Team chat notifications |
+| `telegram` | Telegram Bot API | Mobile alerts, small teams, channels |
 
 ## Webhook (Generic HTTP)
 
@@ -259,6 +260,77 @@ Log time: 15/01/2026 11:00:00 CET
 ```
 
 This helps operators quickly locate the original log entry in VictoriaLogs.
+
+## Telegram
+
+Send alerts to one or more Telegram chats via the Bot API.
+
+### Prerequisites
+
+1. Create a bot via [@BotFather](https://t.me/BotFather) and note the token it gives you.
+2. Add the bot to each target chat/group/channel — it must be a member (or admin, for channels) to post.
+3. Get the `chat_id` for each destination. The simplest way: send a message in the chat, then call `https://api.telegram.org/bot<TOKEN>/getUpdates` and read `chat.id` from the response. For channels the id is negative (starts with `-100`).
+
+### Configuration
+
+```yaml
+notifiers:
+  telegram-alerts:
+    type: telegram
+    bot_token: "${TELEGRAM_BOT_TOKEN}"   # REQUIRED (supports ${ENV_VAR})
+    chat_ids:                             # REQUIRED (non-empty)
+      - "-100123456789"
+      - "-100987654321"
+    parse_mode: HTML                      # Optional (default: HTML)
+    disable_notification: false           # Optional (silent delivery)
+    disable_web_page_preview: true        # Optional (avoid link-preview noise)
+    body_template: |                      # Optional (Jinja)
+      <b>{{ title|e }}</b>
+      {{ body|e }}
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `bot_token` | Yes | Bot API token from @BotFather. Stored as a secret; never logged. |
+| `chat_ids` | Yes | List of target chat IDs. Must be non-empty; each element must be non-empty. |
+| `parse_mode` | No | `HTML` (default) or `MarkdownV2`. Passed through to the Bot API. |
+| `disable_notification` | No | When `true`, Telegram delivers silently (no push sound). |
+| `disable_web_page_preview` | No | When `true`, Telegram does not expand link previews. |
+| `body_template` | No | Jinja template for the message text. Defaults to `<b>{{ title\|e }}</b>\n{{ body\|e }}`. |
+
+### Multi-chat delivery
+
+Each `chat_id` receives one **sequential** `sendMessage` call — Telegram rate-limits at 1 message per second per chat, so parallel delivery wouldn't help. The order in `chat_ids` is preserved.
+
+If at least one chat succeeds, the alert is counted as delivered (`Ok`). Per-chat failures are logged at `error` level and recorded in `valerter_notify_errors_total` / `valerter_alerts_failed_total`.
+
+### Message length
+
+Telegram's hard limit is **4096 Unicode codepoints** per message. Longer messages are truncated to 4095 codepoints + `…` (one Unicode codepoint). Each truncation increments `valerter_alerts_truncated_total{notifier_type="telegram"}` **once per alert** (not per chat) and emits a `warn` log.
+
+### Rate limits and retries
+
+Telegram returns HTTP 429 with a `Retry-After` header when you hit a rate limit. The notifier honors it (clamped to `[1s, 60s]`) and the retry counts against the same 3-attempt pool as 5xx and network errors.
+
+### HTML escaping
+
+With `parse_mode: HTML`, Telegram rejects messages containing unescaped `<`, `>`, or `&`. The default `body_template` uses the `|e` Jinja filter to escape these automatically. If you provide a custom `body_template`, make sure to escape user-controlled fields (`title`, `body`) the same way, or your messages will be rejected with a 400.
+
+### Example: two destinations, silent delivery
+
+```yaml
+notifiers:
+  telegram-oncall:
+    type: telegram
+    bot_token: "${TELEGRAM_BOT_TOKEN}"
+    chat_ids:
+      - "-1001111111111"   # #oncall channel
+      - "-1002222222222"   # #leadership channel
+    disable_notification: false
+    disable_web_page_preview: true
+```
 
 ## Multi-Destination Routing
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,7 +14,7 @@ mod validation;
 pub use env::{resolve_body_template, resolve_env_vars};
 pub use notifiers::{
     EmailNotifierConfig, MattermostNotifierConfig, NotifierConfig, NotifiersConfig, SmtpConfig,
-    TlsMode, WebhookNotifierConfig,
+    TelegramNotifierConfig, TlsMode, WebhookNotifierConfig,
 };
 pub use runtime::{
     CompiledParser, CompiledRule, CompiledTemplate, CompiledThrottle, RuntimeConfig,

--- a/src/config/notifiers.rs
+++ b/src/config/notifiers.rs
@@ -17,6 +17,8 @@ pub enum NotifierConfig {
     Webhook(WebhookNotifierConfig),
     #[serde(rename = "email")]
     Email(EmailNotifierConfig),
+    #[serde(rename = "telegram")]
+    Telegram(TelegramNotifierConfig),
 }
 
 /// Configuration for a Mattermost notifier instance.
@@ -59,6 +61,28 @@ pub struct EmailNotifierConfig {
     pub body_template: Option<String>,
     #[serde(default)]
     pub body_template_file: Option<String>,
+}
+
+/// Configuration for a Telegram Bot notifier instance.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TelegramNotifierConfig {
+    /// Bot API token (supports `${ENV_VAR}` substitution).
+    pub bot_token: String,
+    /// One or more Telegram chat IDs to send messages to. Must be non-empty.
+    pub chat_ids: Vec<String>,
+    /// Telegram parse mode for the message text. Defaults to `HTML`.
+    #[serde(default)]
+    pub parse_mode: Option<String>,
+    /// When true, delivery is silent (no push sound).
+    #[serde(default)]
+    pub disable_notification: Option<bool>,
+    /// When true, Telegram does not expand link previews in the message.
+    #[serde(default)]
+    pub disable_web_page_preview: Option<bool>,
+    /// Optional Jinja template for the message body. Defaults to the built-in HTML template.
+    #[serde(default)]
+    pub body_template: Option<String>,
 }
 
 /// SMTP server configuration.
@@ -153,6 +177,68 @@ mod tests {
             }
             _ => panic!("Expected Email variant"),
         }
+    }
+
+    #[test]
+    fn telegram_notifier_config_parses() {
+        let yaml = r#"
+            type: telegram
+            bot_token: "${TELEGRAM_BOT_TOKEN}"
+            chat_ids:
+              - "-100123456789"
+              - "-100987654321"
+            parse_mode: HTML
+            disable_notification: false
+            disable_web_page_preview: true
+        "#;
+        let config: NotifierConfig = serde_yaml::from_str(yaml).unwrap();
+        match config {
+            NotifierConfig::Telegram(cfg) => {
+                assert_eq!(cfg.bot_token, "${TELEGRAM_BOT_TOKEN}");
+                assert_eq!(cfg.chat_ids.len(), 2);
+                assert_eq!(cfg.parse_mode.as_deref(), Some("HTML"));
+                assert_eq!(cfg.disable_notification, Some(false));
+                assert_eq!(cfg.disable_web_page_preview, Some(true));
+                assert!(cfg.body_template.is_none());
+            }
+            _ => panic!("Expected Telegram variant"),
+        }
+    }
+
+    #[test]
+    fn telegram_notifier_config_defaults() {
+        let yaml = r#"
+            type: telegram
+            bot_token: "token123"
+            chat_ids: ["-100"]
+        "#;
+        let config: NotifierConfig = serde_yaml::from_str(yaml).unwrap();
+        match config {
+            NotifierConfig::Telegram(cfg) => {
+                assert_eq!(cfg.bot_token, "token123");
+                assert_eq!(cfg.chat_ids, vec!["-100".to_string()]);
+                assert!(cfg.parse_mode.is_none());
+                assert!(cfg.disable_notification.is_none());
+                assert!(cfg.disable_web_page_preview.is_none());
+                assert!(cfg.body_template.is_none());
+            }
+            _ => panic!("Expected Telegram variant"),
+        }
+    }
+
+    #[test]
+    fn telegram_notifier_config_rejects_unknown_fields() {
+        let yaml = r#"
+            type: telegram
+            bot_token: "x"
+            chat_ids: ["-1"]
+            icon_url: "nope"
+        "#;
+        let result: Result<NotifierConfig, _> = serde_yaml::from_str(yaml);
+        assert!(
+            result.is_err(),
+            "icon_url should be rejected by deny_unknown_fields"
+        );
     }
 
     #[test]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1847,3 +1847,80 @@ rules:
         "Invalid URL in webhook notifier should be rejected"
     );
 }
+
+#[test]
+fn telegram_notifier_with_empty_chat_ids_fails_validation() {
+    let yaml = r#"
+victorialogs:
+  url: http://localhost:9428
+notifiers:
+  telegram-broken:
+    type: telegram
+    bot_token: "token"
+    chat_ids: []
+defaults:
+  throttle:
+    count: 5
+    window: 1m
+templates:
+  default:
+    title: "Test"
+    body: "Test body"
+rules:
+  - name: test_rule
+    query: "test"
+    parser:
+      json:
+        fields: ["host"]
+    notify:
+      template: "default"
+      destinations: ["telegram-broken"]
+"#;
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    let errors = config.validate().unwrap_err();
+    let has_chat_ids_error = errors.iter().any(|e| {
+        matches!(e, crate::error::ConfigError::ValidationError(msg)
+            if msg.contains("telegram-broken") && msg.contains("chat_ids must not be empty"))
+    });
+    assert!(
+        has_chat_ids_error,
+        "Expected chat_ids validation error, got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn telegram_notifier_with_populated_chat_ids_passes_validation() {
+    let yaml = r#"
+victorialogs:
+  url: http://localhost:9428
+notifiers:
+  telegram-ok:
+    type: telegram
+    bot_token: "token"
+    chat_ids:
+      - "-100123"
+defaults:
+  throttle:
+    count: 5
+    window: 1m
+templates:
+  default:
+    title: "Test"
+    body: "Test body"
+rules:
+  - name: test_rule
+    query: "test"
+    parser:
+      json:
+        fields: ["host"]
+    notify:
+      template: "default"
+      destinations: ["telegram-ok"]
+"#;
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    assert!(
+        config.validate().is_ok(),
+        "Telegram notifier with non-empty chat_ids should validate"
+    );
+}

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -501,6 +501,14 @@ impl Config {
                     super::notifiers::NotifierConfig::Email(_) => {
                         // Email notifier doesn't have URLs to validate
                     }
+                    super::notifiers::NotifierConfig::Telegram(cfg) => {
+                        if cfg.chat_ids.is_empty() {
+                            errors.push(ConfigError::ValidationError(format!(
+                                "notifier '{}': chat_ids must not be empty",
+                                name
+                            )));
+                        }
+                    }
                 }
             }
         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -50,6 +50,10 @@ pub fn register_metric_descriptions() {
         "Total number of notification errors after retries exhausted"
     );
     describe_counter!(
+        "valerter_alerts_truncated_total",
+        "Total number of alerts whose message body was truncated to fit the notifier length limit"
+    );
+    describe_counter!(
         "valerter_parse_errors_total",
         "Total number of log parsing errors (regex no-match or invalid JSON)"
     );

--- a/src/notify/mod.rs
+++ b/src/notify/mod.rs
@@ -13,6 +13,7 @@ mod traits;
 
 pub mod email;
 pub mod mattermost;
+pub mod telegram;
 pub mod webhook;
 
 // Re-exports
@@ -21,6 +22,7 @@ pub use mattermost::MattermostNotifier;
 pub use payload::{AlertPayload, format_log_timestamp};
 pub use queue::{DEFAULT_QUEUE_CAPACITY, NotificationQueue, NotificationWorker, backoff_delay};
 pub use registry::NotifierRegistry;
+pub use telegram::TelegramNotifier;
 pub use traits::Notifier;
 pub use webhook::WebhookNotifier;
 

--- a/src/notify/registry.rs
+++ b/src/notify/registry.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::config::{NotifierConfig, NotifiersConfig, SecretString, resolve_env_vars};
 use crate::error::ConfigError;
 
-use super::{EmailNotifier, MattermostNotifier, Notifier, WebhookNotifier};
+use super::{EmailNotifier, MattermostNotifier, Notifier, TelegramNotifier, WebhookNotifier};
 
 /// Registry for managing named notifiers.
 ///
@@ -211,6 +211,18 @@ impl NotifierRegistry {
                     from = %email_config.from,
                     to_count = email_config.to.len(),
                     "Registered email notifier from config"
+                );
+
+                Ok(Arc::new(notifier))
+            }
+            NotifierConfig::Telegram(tg_config) => {
+                let notifier = TelegramNotifier::from_config(name, tg_config, http_client.clone())?;
+
+                tracing::debug!(
+                    notifier_name = %name,
+                    notifier_type = "telegram",
+                    chat_count = tg_config.chat_ids.len(),
+                    "Registered telegram notifier from config"
                 );
 
                 Ok(Arc::new(notifier))

--- a/src/notify/telegram.rs
+++ b/src/notify/telegram.rs
@@ -700,6 +700,7 @@ mod tests {
     // earlier unit tests cannot exercise. Requests are redirected to a local
     // wiremock server via `TelegramNotifier::new_for_tests`.
 
+    use serial_test::serial;
     use wiremock::matchers::{body_partial_json, method, path_regex};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -710,6 +711,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn send_all_chats_success_returns_ok() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -727,6 +729,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn send_partial_success_returns_ok_and_does_not_stop_after_failure() {
         let server = MockServer::start().await;
         // Every chat gets 200 — we verify the important property: 3 requests
@@ -753,6 +756,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn send_one_permanent_failure_in_middle_still_returns_ok_partial() {
         // wiremock can't route per chat_id (it's in the JSON body), but we can
         // assert the partial-success behaviour by exhausting a single mock
@@ -795,6 +799,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn send_all_chats_permanent_failure_returns_err() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -814,6 +819,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn send_payload_has_expected_fields() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -833,6 +839,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn send_retries_on_5xx_then_succeeds() {
         let server = MockServer::start().await;
         let calls = Arc::new(AtomicU32::new(0));
@@ -859,6 +866,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn send_exhausts_retries_on_persistent_5xx() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -875,26 +883,28 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn send_network_error_exhausts_retries() {
-        // Start then immediately drop the mock server so requests fail at the
-        // TCP level. Gives us coverage of the Err(reqwest::Error) branch in
-        // the retry loop.
-        let server = MockServer::start().await;
-        let uri = server.uri();
-        drop(server);
-        let endpoint = format!("{}/botTESTTOKEN/sendMessage", uri);
-        let notifier = TelegramNotifier::new_for_tests(
-            "tg-test",
-            endpoint,
-            vec!["-100A".to_string()],
-            reqwest::Client::new(),
-        );
+        // Point the notifier at a TEST-NET-1 address (RFC 5737, reserved for
+        // documentation and never routed). The connection attempt fails at
+        // the TCP level, exercising the Err(reqwest::Error) branch of the
+        // retry loop without depending on a released port.
+        let endpoint = "http://192.0.2.1:1/botTESTTOKEN/sendMessage".to_string();
+        // Short timeout on the shared client so the test doesn't take 30s
+        // waiting for three TCP timeouts to fire.
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_millis(200))
+            .build()
+            .unwrap();
+        let notifier =
+            TelegramNotifier::new_for_tests("tg-test", endpoint, vec!["-100A".to_string()], client);
         let alert = sample_alert("hi", "body");
         let err = notifier.send(&alert).await.unwrap_err();
         assert!(matches!(err, NotifyError::SendFailed(_)));
     }
 
     #[tokio::test]
+    #[serial]
     async fn send_body_under_limit_is_not_truncated() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))

--- a/src/notify/telegram.rs
+++ b/src/notify/telegram.rs
@@ -833,6 +833,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn send_retries_on_5xx_then_succeeds() {
+        let server = MockServer::start().await;
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_clone = calls.clone();
+        Mock::given(method("POST"))
+            .respond_with(move |_req: &wiremock::Request| {
+                let n = calls_clone.fetch_add(1, Ordering::SeqCst);
+                if n == 0 {
+                    ResponseTemplate::new(503).set_body_string("server error")
+                } else {
+                    ResponseTemplate::new(200).set_body_string("{\"ok\":true}")
+                }
+            })
+            .mount(&server)
+            .await;
+
+        let notifier = test_notifier(&server, vec!["-100A".to_string()]);
+        let alert = sample_alert("hi", "body");
+        notifier
+            .send(&alert)
+            .await
+            .expect("should succeed after 5xx retry");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn send_exhausts_retries_on_persistent_5xx() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(502).set_body_string("bad gateway"))
+            .expect(3)
+            .mount(&server)
+            .await;
+
+        let notifier = test_notifier(&server, vec!["-100A".to_string()]);
+        let alert = sample_alert("hi", "body");
+        let err = notifier.send(&alert).await.unwrap_err();
+        assert!(matches!(err, NotifyError::SendFailed(_)));
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn send_network_error_exhausts_retries() {
+        // Start then immediately drop the mock server so requests fail at the
+        // TCP level. Gives us coverage of the Err(reqwest::Error) branch in
+        // the retry loop.
+        let server = MockServer::start().await;
+        let uri = server.uri();
+        drop(server);
+        let endpoint = format!("{}/botTESTTOKEN/sendMessage", uri);
+        let notifier = TelegramNotifier::new_for_tests(
+            "tg-test",
+            endpoint,
+            vec!["-100A".to_string()],
+            reqwest::Client::new(),
+        );
+        let alert = sample_alert("hi", "body");
+        let err = notifier.send(&alert).await.unwrap_err();
+        assert!(matches!(err, NotifyError::SendFailed(_)));
+    }
+
+    #[tokio::test]
     async fn send_body_under_limit_is_not_truncated() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))

--- a/src/notify/telegram.rs
+++ b/src/notify/telegram.rs
@@ -1,0 +1,859 @@
+//! Telegram Bot notifier implementation.
+//!
+//! Sends alerts via the Bot API `sendMessage` endpoint. One HTTP call per
+//! configured `chat_id`, sequentially — Telegram rate-limits at 1 msg/sec/chat,
+//! so batching would not help. The notifier returns `Ok(())` as soon as at
+//! least one chat succeeds (partial success); `Err` only when all fail.
+
+use crate::config::{SecretString, TelegramNotifierConfig, resolve_env_vars};
+use crate::error::{ConfigError, NotifyError};
+use crate::notify::{AlertPayload, Notifier, backoff_delay};
+use async_trait::async_trait;
+use minijinja::{Environment, context};
+use serde::Serialize;
+use std::time::Duration;
+use tracing::Instrument;
+
+/// Backoff base delay for Telegram retries.
+const TELEGRAM_BACKOFF_BASE: Duration = Duration::from_millis(500);
+
+/// Maximum backoff delay for Telegram retries.
+const TELEGRAM_BACKOFF_MAX: Duration = Duration::from_secs(5);
+
+/// Maximum number of retry attempts (pool partagé 5xx + réseau + 429).
+const TELEGRAM_MAX_RETRIES: u32 = 3;
+
+/// Per-request HTTP timeout.
+const TELEGRAM_HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Floor applied to a parsed `Retry-After` value. Guards against tight retry
+/// loops on `Retry-After: 0` or malformed floats that round down to zero.
+const RETRY_AFTER_MIN: Duration = Duration::from_secs(1);
+
+/// Ceiling applied to a parsed `Retry-After` value. Protects against an
+/// adversarial or misconfigured upstream sending us a delay measured in hours.
+const RETRY_AFTER_MAX: Duration = Duration::from_secs(60);
+
+/// Telegram `sendMessage` hard limit on `text` (in Unicode codepoints).
+const TELEGRAM_TEXT_MAX_CODEPOINTS: usize = 4096;
+
+/// Default `body_template` when none is configured. The `|e` filter escapes
+/// `< > &` so the HTML `parse_mode` does not choke on raw symbols coming
+/// from log bodies.
+const DEFAULT_BODY_TEMPLATE: &str = "<b>{{ title|e }}</b>\n{{ body|e }}";
+
+/// Default `parse_mode` sent to Telegram when none is configured.
+const DEFAULT_PARSE_MODE: &str = "HTML";
+
+/// Payload serialized as the body of a `sendMessage` request.
+#[derive(Debug, Serialize)]
+struct TelegramPayload<'a> {
+    chat_id: &'a str,
+    text: &'a str,
+    parse_mode: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    disable_notification: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    disable_web_page_preview: Option<bool>,
+}
+
+/// Truncate `text` so that it does not exceed [`TELEGRAM_TEXT_MAX_CODEPOINTS`]
+/// Unicode codepoints. When truncation happens, a single `…` (U+2026) is
+/// appended so the final codepoint count is exactly the limit.
+fn truncate_text(text: &str) -> (String, bool) {
+    if text.chars().count() <= TELEGRAM_TEXT_MAX_CODEPOINTS {
+        return (text.to_string(), false);
+    }
+    let mut out: String = text
+        .chars()
+        .take(TELEGRAM_TEXT_MAX_CODEPOINTS - 1)
+        .collect();
+    out.push('…');
+    (out, true)
+}
+
+/// Validate a `body_template` at configuration time so startup fails fast on
+/// malformed Jinja.
+fn validate_body_template(source: &str) -> Result<(), ConfigError> {
+    let mut env = Environment::new();
+    env.add_template("_validate", source)
+        .map_err(|e| ConfigError::InvalidTemplate {
+            rule: "telegram.body_template".to_string(),
+            message: e.to_string(),
+        })?;
+    Ok(())
+}
+
+/// Render a body template with alert context.
+fn render_body_template(source: &str, alert: &AlertPayload) -> Result<String, NotifyError> {
+    let mut env = Environment::new();
+    env.add_template("body", source)
+        .map_err(|e| NotifyError::TemplateError(e.to_string()))?;
+    let tmpl = env
+        .get_template("body")
+        .map_err(|e| NotifyError::TemplateError(e.to_string()))?;
+    tmpl.render(context! {
+        title => &alert.message.title,
+        body => &alert.message.body,
+        rule_name => &alert.rule_name,
+        log_timestamp => &alert.log_timestamp,
+        log_timestamp_formatted => &alert.log_timestamp_formatted,
+    })
+    .map_err(|e| NotifyError::TemplateError(e.to_string()))
+}
+
+/// Clamp a parsed retry-after value to the `[RETRY_AFTER_MIN, RETRY_AFTER_MAX]`
+/// window. A zero or near-zero value is bumped up to 1s to avoid tight loops;
+/// a very large value is capped so we never hold an executor hostage on
+/// adversarial input.
+fn clamp_retry_after(seconds: f64) -> Duration {
+    let clamped = seconds
+        .max(RETRY_AFTER_MIN.as_secs_f64())
+        .min(RETRY_AFTER_MAX.as_secs_f64());
+    Duration::from_secs_f64(clamped)
+}
+
+/// Parse a `Retry-After` string as an integer first (fastest path), then fall
+/// back to a float parse to accept values like `"1.5"` which some proxies emit.
+fn parse_retry_after_value(s: &str) -> Option<f64> {
+    let trimmed = s.trim();
+    if let Ok(n) = trimmed.parse::<u64>() {
+        return Some(n as f64);
+    }
+    trimmed.parse::<f64>().ok().filter(|f| f.is_finite())
+}
+
+/// Pure parsing logic for the retry-after chain — unit-tested directly.
+fn extract_retry_after(header: Option<&str>, body: &str, attempt: u32) -> Duration {
+    if let Some(raw) = header
+        && let Some(secs) = parse_retry_after_value(raw)
+    {
+        return clamp_retry_after(secs);
+    }
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(body)
+        && let Some(secs) = json
+            .get("parameters")
+            .and_then(|p| p.get("retry_after"))
+            .and_then(|v| v.as_f64().or_else(|| v.as_u64().map(|n| n as f64)))
+    {
+        return clamp_retry_after(secs);
+    }
+    backoff_delay(attempt, TELEGRAM_BACKOFF_BASE, TELEGRAM_BACKOFF_MAX)
+}
+
+/// Extract a retry-after duration after a 429 response. Tries the HTTP header
+/// first, then the JSON body `parameters.retry_after`, then falls back to the
+/// standard exponential backoff. Safe on malformed input — never panics.
+async fn parse_retry_after(response: reqwest::Response, attempt: u32) -> Duration {
+    let header = response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let body = response.text().await.unwrap_or_default();
+    extract_retry_after(header.as_deref(), &body, attempt)
+}
+
+/// Telegram Bot notifier. One instance per configured `notifiers.<name>` entry.
+pub struct TelegramNotifier {
+    name: String,
+    /// Full Bot API endpoint including the token
+    /// (`https://api.telegram.org/bot<token>/sendMessage`). Stored as
+    /// [`SecretString`] so it never leaks through `Debug` or tracing.
+    endpoint: SecretString,
+    client: reqwest::Client,
+    chat_ids: Vec<String>,
+    parse_mode: String,
+    disable_notification: Option<bool>,
+    disable_web_page_preview: Option<bool>,
+    body_template_source: Option<String>,
+}
+
+impl TelegramNotifier {
+    /// Build a notifier from its validated configuration.
+    pub fn from_config(
+        name: &str,
+        config: &TelegramNotifierConfig,
+        client: reqwest::Client,
+    ) -> Result<Self, ConfigError> {
+        if config.chat_ids.is_empty() {
+            return Err(ConfigError::InvalidNotifier {
+                name: name.to_string(),
+                message: "chat_ids must not be empty".to_string(),
+            });
+        }
+        if let Some((index, _)) = config
+            .chat_ids
+            .iter()
+            .enumerate()
+            .find(|(_, id)| id.trim().is_empty())
+        {
+            return Err(ConfigError::InvalidNotifier {
+                name: name.to_string(),
+                message: format!("chat_ids[{}] must not be empty", index),
+            });
+        }
+
+        let resolved_token =
+            resolve_env_vars(&config.bot_token).map_err(|e| ConfigError::InvalidNotifier {
+                name: name.to_string(),
+                message: format!("bot_token: {}", e),
+            })?;
+        if resolved_token.trim().is_empty() {
+            return Err(ConfigError::InvalidNotifier {
+                name: name.to_string(),
+                message: "bot_token resolved to an empty value".to_string(),
+            });
+        }
+
+        if let Some(template) = &config.body_template {
+            validate_body_template(template).map_err(|e| ConfigError::InvalidNotifier {
+                name: name.to_string(),
+                message: format!("body_template: {}", e),
+            })?;
+        }
+
+        let endpoint = format!("https://api.telegram.org/bot{}/sendMessage", resolved_token);
+
+        Ok(Self {
+            name: name.to_string(),
+            endpoint: SecretString::new(endpoint),
+            client,
+            chat_ids: config.chat_ids.clone(),
+            parse_mode: config
+                .parse_mode
+                .clone()
+                .unwrap_or_else(|| DEFAULT_PARSE_MODE.to_string()),
+            disable_notification: config.disable_notification,
+            disable_web_page_preview: config.disable_web_page_preview,
+            body_template_source: config.body_template.clone(),
+        })
+    }
+
+    /// Render and truncate the message text once, before fan-out to chats.
+    fn prepare_text(&self, alert: &AlertPayload) -> Result<(String, bool), NotifyError> {
+        let template = self
+            .body_template_source
+            .as_deref()
+            .unwrap_or(DEFAULT_BODY_TEMPLATE);
+        let rendered = render_body_template(template, alert)?;
+        Ok(truncate_text(&rendered))
+    }
+
+    /// Send the prepared text to a single chat_id with retry. Returns `Ok` on
+    /// success, `Err` on permanent failure (retries exhausted or 4xx other
+    /// than 429).
+    async fn send_to_chat(
+        &self,
+        alert: &AlertPayload,
+        chat_id: &str,
+        text: &str,
+    ) -> Result<(), NotifyError> {
+        let payload = TelegramPayload {
+            chat_id,
+            text,
+            parse_mode: &self.parse_mode,
+            disable_notification: self.disable_notification,
+            disable_web_page_preview: self.disable_web_page_preview,
+        };
+
+        for attempt in 0..TELEGRAM_MAX_RETRIES {
+            let result = self
+                .client
+                .post(self.endpoint.expose())
+                .timeout(TELEGRAM_HTTP_TIMEOUT)
+                .json(&payload)
+                .send()
+                .await;
+
+            match result {
+                Ok(response) if response.status().is_success() => {
+                    tracing::debug!(chat_id = %chat_id, "Telegram alert sent");
+                    return Ok(());
+                }
+                Ok(response) if response.status().as_u16() == 429 => {
+                    let delay = parse_retry_after(response, attempt).await;
+                    tracing::warn!(
+                        attempt = attempt,
+                        chat_id = %chat_id,
+                        delay_ms = delay.as_millis() as u64,
+                        "Telegram rate-limited, waiting"
+                    );
+                    if attempt < TELEGRAM_MAX_RETRIES - 1 {
+                        tokio::time::sleep(delay).await;
+                    }
+                    continue;
+                }
+                Ok(response) if response.status().is_client_error() => {
+                    let status = response.status();
+                    tracing::error!(
+                        chat_id = %chat_id,
+                        status = %status,
+                        "Telegram returned client error, not retrying"
+                    );
+                    return Err(NotifyError::SendFailed(format!("client error: {}", status)));
+                }
+                Ok(response) => {
+                    tracing::warn!(
+                        attempt = attempt,
+                        chat_id = %chat_id,
+                        status = %response.status(),
+                        "Telegram returned server error, retrying"
+                    );
+                }
+                Err(e) => {
+                    // `reqwest::Error` includes the full request URL (which
+                    // contains the bot token) in its Display. Strip it before
+                    // logging.
+                    tracing::warn!(
+                        attempt = attempt,
+                        chat_id = %chat_id,
+                        error = %e.without_url(),
+                        "Telegram request failed, retrying"
+                    );
+                }
+            }
+
+            if attempt < TELEGRAM_MAX_RETRIES - 1 {
+                let delay = backoff_delay(attempt, TELEGRAM_BACKOFF_BASE, TELEGRAM_BACKOFF_MAX);
+                tokio::time::sleep(delay).await;
+            }
+        }
+
+        tracing::error!(
+            chat_id = %chat_id,
+            max_retries = TELEGRAM_MAX_RETRIES,
+            rule_name = %alert.rule_name,
+            "Telegram send exhausted retries"
+        );
+        Err(NotifyError::MaxRetriesExceeded)
+    }
+}
+
+#[async_trait]
+impl Notifier for TelegramNotifier {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn notifier_type(&self) -> &str {
+        "telegram"
+    }
+
+    async fn send(&self, alert: &AlertPayload) -> Result<(), NotifyError> {
+        let span = tracing::info_span!(
+            "send_telegram",
+            rule_name = %alert.rule_name,
+            notifier_name = %self.name,
+            chat_count = self.chat_ids.len()
+        );
+
+        async {
+            let (text, truncated) = self.prepare_text(alert)?;
+            if truncated {
+                tracing::warn!(
+                    rule_name = %alert.rule_name,
+                    limit = TELEGRAM_TEXT_MAX_CODEPOINTS,
+                    "Telegram message truncated to fit codepoint limit"
+                );
+                metrics::counter!(
+                    "valerter_alerts_truncated_total",
+                    "notifier_type" => "telegram",
+                    "notifier_name" => self.name.clone()
+                )
+                .increment(1);
+            }
+
+            let mut any_success = false;
+            for chat_id in &self.chat_ids {
+                match self.send_to_chat(alert, chat_id, &text).await {
+                    Ok(()) => {
+                        any_success = true;
+                        metrics::counter!(
+                            "valerter_alerts_sent_total",
+                            "rule_name" => alert.rule_name.clone(),
+                            "notifier_name" => self.name.clone(),
+                            "notifier_type" => "telegram"
+                        )
+                        .increment(1);
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            chat_id = %chat_id,
+                            error = %e,
+                            "Telegram send permanently failed for chat"
+                        );
+                        metrics::counter!(
+                            "valerter_notify_errors_total",
+                            "rule_name" => alert.rule_name.clone(),
+                            "notifier_name" => self.name.clone(),
+                            "notifier_type" => "telegram"
+                        )
+                        .increment(1);
+                        metrics::counter!(
+                            "valerter_alerts_failed_total",
+                            "rule_name" => alert.rule_name.clone(),
+                            "notifier_name" => self.name.clone(),
+                            "notifier_type" => "telegram"
+                        )
+                        .increment(1);
+                    }
+                }
+            }
+
+            if any_success {
+                Ok(())
+            } else {
+                Err(NotifyError::SendFailed("all chat_ids failed".to_string()))
+            }
+        }
+        .instrument(span)
+        .await
+    }
+}
+
+#[cfg(test)]
+impl TelegramNotifier {
+    /// Test-only constructor that bypasses the real Bot API URL. Used by
+    /// integration tests to redirect requests to a wiremock server.
+    pub(crate) fn new_for_tests(
+        name: &str,
+        endpoint: String,
+        chat_ids: Vec<String>,
+        client: reqwest::Client,
+    ) -> Self {
+        Self {
+            name: name.to_string(),
+            endpoint: SecretString::new(endpoint),
+            client,
+            chat_ids,
+            parse_mode: DEFAULT_PARSE_MODE.to_string(),
+            disable_notification: None,
+            disable_web_page_preview: None,
+            body_template_source: None,
+        }
+    }
+}
+
+impl std::fmt::Debug for TelegramNotifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never leak endpoint (contains the bot token) or chat_ids.
+        f.debug_struct("TelegramNotifier")
+            .field("name", &self.name)
+            .field("chat_count", &self.chat_ids.len())
+            .field("parse_mode", &self.parse_mode)
+            .field("has_body_template", &self.body_template_source.is_some())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::template::RenderedMessage;
+
+    fn sample_alert(title: &str, body: &str) -> AlertPayload {
+        AlertPayload {
+            message: RenderedMessage {
+                title: title.to_string(),
+                body: body.to_string(),
+                body_html: None,
+                accent_color: None,
+            },
+            rule_name: "test_rule".to_string(),
+            destinations: vec![],
+            log_timestamp: "2026-04-14T10:00:00Z".to_string(),
+            log_timestamp_formatted: "14/04/2026 10:00:00 UTC".to_string(),
+        }
+    }
+
+    fn config_with(chat_ids: Vec<String>) -> TelegramNotifierConfig {
+        TelegramNotifierConfig {
+            bot_token: "fake-token".to_string(),
+            chat_ids,
+            parse_mode: None,
+            disable_notification: None,
+            disable_web_page_preview: None,
+            body_template: None,
+        }
+    }
+
+    #[test]
+    fn truncate_text_leaves_short_text_alone() {
+        let input = "hello";
+        let (out, was_truncated) = truncate_text(input);
+        assert_eq!(out, "hello");
+        assert!(!was_truncated);
+    }
+
+    #[test]
+    fn truncate_text_allows_exact_limit() {
+        let input: String = "a".repeat(TELEGRAM_TEXT_MAX_CODEPOINTS);
+        let (out, was_truncated) = truncate_text(&input);
+        assert_eq!(out.chars().count(), TELEGRAM_TEXT_MAX_CODEPOINTS);
+        assert!(!was_truncated);
+    }
+
+    #[test]
+    fn truncate_text_cuts_over_limit_to_exactly_4096_codepoints() {
+        let input: String = "a".repeat(TELEGRAM_TEXT_MAX_CODEPOINTS + 1);
+        let (out, was_truncated) = truncate_text(&input);
+        assert!(was_truncated);
+        assert_eq!(out.chars().count(), TELEGRAM_TEXT_MAX_CODEPOINTS);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_text_respects_codepoints_not_bytes_on_multibyte() {
+        // Build a 5000-codepoint string of 4-byte emojis (🌟 = U+1F31F, 4 bytes).
+        let star = "🌟";
+        let input: String = star.repeat(5000);
+        assert!(
+            input.len() > TELEGRAM_TEXT_MAX_CODEPOINTS * 2,
+            "input should be byte-heavy"
+        );
+        let (out, was_truncated) = truncate_text(&input);
+        assert!(was_truncated);
+        // Limit is in codepoints, not bytes.
+        assert_eq!(out.chars().count(), TELEGRAM_TEXT_MAX_CODEPOINTS);
+        assert!(out.ends_with('…'));
+        // First 4095 codepoints must still be intact emojis (no byte splitting).
+        let kept: String = out.chars().take(TELEGRAM_TEXT_MAX_CODEPOINTS - 1).collect();
+        assert_eq!(kept, star.repeat(TELEGRAM_TEXT_MAX_CODEPOINTS - 1));
+    }
+
+    #[test]
+    fn from_config_rejects_empty_chat_ids() {
+        let client = reqwest::Client::new();
+        let cfg = config_with(vec![]);
+        let err = TelegramNotifier::from_config("tg", &cfg, client).unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidNotifier { .. }));
+        assert!(err.to_string().contains("chat_ids"));
+    }
+
+    #[test]
+    fn from_config_fails_fast_on_unresolved_env_var() {
+        let client = reqwest::Client::new();
+        let mut cfg = config_with(vec!["-100".to_string()]);
+        cfg.bot_token = "${VALERTER_TELEGRAM_TEST_MISSING_VAR}".to_string();
+        let err = TelegramNotifier::from_config("tg", &cfg, client).unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidNotifier { .. }));
+        assert!(err.to_string().contains("bot_token"));
+    }
+
+    #[test]
+    fn from_config_rejects_invalid_body_template() {
+        let client = reqwest::Client::new();
+        let mut cfg = config_with(vec!["-100".to_string()]);
+        cfg.body_template = Some("{% broken %}".to_string());
+        let err = TelegramNotifier::from_config("tg", &cfg, client).unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidNotifier { .. }));
+        assert!(err.to_string().contains("body_template"));
+    }
+
+    #[test]
+    fn from_config_applies_defaults() {
+        let client = reqwest::Client::new();
+        let cfg = config_with(vec!["-100".to_string()]);
+        let notifier = TelegramNotifier::from_config("tg", &cfg, client).unwrap();
+        assert_eq!(notifier.name(), "tg");
+        assert_eq!(notifier.notifier_type(), "telegram");
+        assert_eq!(notifier.parse_mode, DEFAULT_PARSE_MODE);
+        assert!(notifier.body_template_source.is_none());
+    }
+
+    #[test]
+    fn default_body_template_escapes_html() {
+        let alert = sample_alert("<script>", "A & B");
+        let rendered = render_body_template(DEFAULT_BODY_TEMPLATE, &alert).unwrap();
+        assert!(!rendered.contains("<script>"));
+        assert!(rendered.contains("&lt;script&gt;"));
+        assert!(rendered.contains("A &amp; B"));
+        assert!(rendered.starts_with("<b>"));
+    }
+
+    #[test]
+    fn debug_impl_does_not_leak_token_or_endpoint() {
+        let client = reqwest::Client::new();
+        let mut cfg = config_with(vec!["-100".to_string()]);
+        cfg.bot_token = "SUPER_SECRET_TOKEN".to_string();
+        let notifier = TelegramNotifier::from_config("tg", &cfg, client).unwrap();
+        let dbg = format!("{:?}", notifier);
+        assert!(dbg.contains("TelegramNotifier"));
+        assert!(dbg.contains("tg"));
+        assert!(!dbg.contains("SUPER_SECRET_TOKEN"));
+        assert!(!dbg.contains("api.telegram.org"));
+    }
+
+    #[test]
+    fn payload_serializes_and_skips_none_options() {
+        let payload = TelegramPayload {
+            chat_id: "-100",
+            text: "hello",
+            parse_mode: "HTML",
+            disable_notification: None,
+            disable_web_page_preview: Some(true),
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("\"chat_id\":\"-100\""));
+        assert!(json.contains("\"text\":\"hello\""));
+        assert!(json.contains("\"parse_mode\":\"HTML\""));
+        assert!(json.contains("\"disable_web_page_preview\":true"));
+        assert!(!json.contains("disable_notification"));
+    }
+
+    #[tokio::test]
+    async fn notifier_trait_is_object_safe() {
+        let client = reqwest::Client::new();
+        let cfg = config_with(vec!["-100".to_string()]);
+        let notifier: Box<dyn Notifier> =
+            Box::new(TelegramNotifier::from_config("tg", &cfg, client).unwrap());
+        assert_eq!(notifier.name(), "tg");
+        assert_eq!(notifier.notifier_type(), "telegram");
+    }
+
+    // ── extract_retry_after ──────────────────────────────────────────────
+
+    #[test]
+    fn extract_retry_after_prefers_valid_header() {
+        let delay = extract_retry_after(Some("7"), r#"{"parameters":{"retry_after":99}}"#, 0);
+        assert_eq!(delay, Duration::from_secs(7));
+    }
+
+    #[test]
+    fn extract_retry_after_falls_back_to_json_on_malformed_header() {
+        let delay = extract_retry_after(
+            Some("not-a-number"),
+            r#"{"parameters":{"retry_after":3}}"#,
+            0,
+        );
+        assert_eq!(delay, Duration::from_secs(3));
+    }
+
+    #[test]
+    fn extract_retry_after_falls_back_to_backoff_when_all_malformed() {
+        let delay = extract_retry_after(Some("???"), "not-json-at-all", 0);
+        assert_eq!(delay, TELEGRAM_BACKOFF_BASE);
+    }
+
+    #[test]
+    fn extract_retry_after_handles_no_header_no_body() {
+        let delay = extract_retry_after(None, "", 0);
+        assert_eq!(delay, TELEGRAM_BACKOFF_BASE);
+    }
+
+    #[test]
+    fn extract_retry_after_handles_missing_retry_after_field() {
+        let delay = extract_retry_after(None, r#"{"parameters":{"other":1}}"#, 0);
+        assert_eq!(delay, TELEGRAM_BACKOFF_BASE);
+    }
+
+    #[test]
+    fn extract_retry_after_parses_float_header() {
+        let delay = extract_retry_after(Some("1.5"), "", 0);
+        // 1.5s is within [MIN, MAX] so we expect the exact clamped value.
+        assert_eq!(delay, Duration::from_secs_f64(1.5));
+    }
+
+    #[test]
+    fn extract_retry_after_bumps_zero_to_min_floor() {
+        let delay = extract_retry_after(Some("0"), "", 0);
+        assert_eq!(delay, RETRY_AFTER_MIN);
+    }
+
+    #[test]
+    fn extract_retry_after_caps_runaway_value() {
+        let delay = extract_retry_after(Some("36000"), "", 0);
+        assert_eq!(delay, RETRY_AFTER_MAX);
+    }
+
+    #[test]
+    fn extract_retry_after_parses_float_json_body() {
+        let delay = extract_retry_after(None, r#"{"parameters":{"retry_after":2.5}}"#, 0);
+        assert_eq!(delay, Duration::from_secs_f64(2.5));
+    }
+
+    // ── Empty-value validation ───────────────────────────────────────────
+
+    #[test]
+    fn from_config_rejects_empty_chat_id_element() {
+        let client = reqwest::Client::new();
+        let cfg = config_with(vec!["-100".to_string(), "   ".to_string()]);
+        let err = TelegramNotifier::from_config("tg", &cfg, client).unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidNotifier { .. }));
+        assert!(err.to_string().contains("chat_ids[1]"));
+    }
+
+    #[test]
+    fn from_config_rejects_empty_resolved_bot_token() {
+        let client = reqwest::Client::new();
+        let mut cfg = config_with(vec!["-100".to_string()]);
+        cfg.bot_token = "   ".to_string();
+        let err = TelegramNotifier::from_config("tg", &cfg, client).unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidNotifier { .. }));
+        assert!(err.to_string().contains("bot_token"));
+    }
+
+    // ── End-to-end send() via wiremock ───────────────────────────────────
+    //
+    // These tests cover AC1, AC7 and the multi-chat retry path that the
+    // earlier unit tests cannot exercise. Requests are redirected to a local
+    // wiremock server via `TelegramNotifier::new_for_tests`.
+
+    use wiremock::matchers::{body_partial_json, method, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_notifier(server: &MockServer, chat_ids: Vec<String>) -> TelegramNotifier {
+        // Use alphanumeric-only path so reqwest doesn't percent-encode anything.
+        let endpoint = format!("{}/botTESTTOKEN/sendMessage", server.uri());
+        TelegramNotifier::new_for_tests("tg-test", endpoint, chat_ids, reqwest::Client::new())
+    }
+
+    #[tokio::test]
+    async fn send_all_chats_success_returns_ok() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex(r"/botTESTTOKEN/sendMessage"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{\"ok\":true}"))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let notifier = test_notifier(&server, vec!["-100A".to_string(), "-100B".to_string()]);
+        let alert = sample_alert("hi", "body");
+        notifier.send(&alert).await.expect("should succeed");
+
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn send_partial_success_returns_ok_and_does_not_stop_after_failure() {
+        let server = MockServer::start().await;
+        // Every chat gets 200 — we verify the important property: 3 requests
+        // are issued in order even when the middle one hits a permanent error
+        // in a separate test. Here we first establish that the multi-chat
+        // fan-out reaches all chats.
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{\"ok\":true}"))
+            .expect(3)
+            .mount(&server)
+            .await;
+
+        let notifier = test_notifier(
+            &server,
+            vec![
+                "-100A".to_string(),
+                "-100B".to_string(),
+                "-100C".to_string(),
+            ],
+        );
+        let alert = sample_alert("hi", "body");
+        notifier.send(&alert).await.expect("should succeed");
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn send_one_permanent_failure_in_middle_still_returns_ok_partial() {
+        // wiremock can't route per chat_id (it's in the JSON body), but we can
+        // assert the partial-success behaviour by exhausting a single mock
+        // endpoint's 200 response after 1 hit then returning 400 for the rest.
+        // The last chat will still fail permanently, but the first success is
+        // enough for the notifier to return Ok.
+        let server = MockServer::start().await;
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_clone = calls.clone();
+        Mock::given(method("POST"))
+            .respond_with(move |_req: &wiremock::Request| {
+                let n = calls_clone.fetch_add(1, Ordering::SeqCst);
+                if n == 0 {
+                    ResponseTemplate::new(200).set_body_string("{\"ok\":true}")
+                } else {
+                    ResponseTemplate::new(400)
+                        .set_body_string("{\"ok\":false,\"description\":\"bad chat\"}")
+                }
+            })
+            .mount(&server)
+            .await;
+
+        let notifier = test_notifier(
+            &server,
+            vec![
+                "-100A".to_string(),
+                "-100B".to_string(),
+                "-100C".to_string(),
+            ],
+        );
+        let alert = sample_alert("hi", "body");
+        notifier
+            .send(&alert)
+            .await
+            .expect("partial success should be Ok");
+
+        // 1 success + 2 permanent failures = 3 requests. The failing chats are
+        // 4xx so there is no retry.
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn send_all_chats_permanent_failure_returns_err() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(400)
+                    .set_body_string("{\"ok\":false,\"description\":\"bad chat\"}"),
+            )
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let notifier = test_notifier(&server, vec!["-100A".to_string(), "-100B".to_string()]);
+        let alert = sample_alert("hi", "body");
+        let err = notifier.send(&alert).await.unwrap_err();
+        assert!(matches!(err, NotifyError::SendFailed(_)));
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn send_payload_has_expected_fields() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(body_partial_json(serde_json::json!({
+                "chat_id": "-100A",
+                "parse_mode": "HTML",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{\"ok\":true}"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let notifier = test_notifier(&server, vec!["-100A".to_string()]);
+        let alert = sample_alert("Hello", "World");
+        notifier.send(&alert).await.expect("should succeed");
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn send_body_under_limit_is_not_truncated() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(body_partial_json(serde_json::json!({
+                // Default template renders "<b>{{title|e}}</b>\n{{body|e}}" so
+                // the exact body text for a short input is deterministic.
+                "text": "<b>hello</b>\nworld",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{\"ok\":true}"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let notifier = test_notifier(&server, vec!["-100A".to_string()]);
+        let alert = sample_alert("hello", "world");
+        notifier.send(&alert).await.expect("should succeed");
+        server.verify().await;
+    }
+
+    // ── Imports for the wiremock tests (kept near the tests to minimize
+    //    churn in the rest of the module).
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+}

--- a/src/notify/tests.rs
+++ b/src/notify/tests.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 
 use crate::config::{
-    EmailNotifierConfig, MattermostNotifierConfig, NotifierConfig, SmtpConfig, TlsMode,
-    WebhookNotifierConfig,
+    EmailNotifierConfig, MattermostNotifierConfig, NotifierConfig, SmtpConfig,
+    TelegramNotifierConfig, TlsMode, WebhookNotifierConfig,
 };
 use crate::error::NotifyError;
 use crate::template::RenderedMessage;
@@ -940,4 +940,61 @@ fn registry_from_config_all_three_notifier_types() {
             assert_eq!(registry.get("email").unwrap().notifier_type(), "email");
         },
     );
+}
+
+#[test]
+#[serial]
+fn registry_from_config_creates_telegram_notifier() {
+    let mut notifiers_config = HashMap::new();
+    notifiers_config.insert(
+        "telegram-infra".to_string(),
+        NotifierConfig::Telegram(TelegramNotifierConfig {
+            bot_token: "fake-token-123".to_string(),
+            chat_ids: vec!["-100123".to_string(), "-100456".to_string()],
+            parse_mode: Some("HTML".to_string()),
+            disable_notification: None,
+            disable_web_page_preview: Some(true),
+            body_template: None,
+        }),
+    );
+
+    let client = reqwest::Client::new();
+    let result = NotifierRegistry::from_config(&notifiers_config, client, &test_config_dir());
+
+    assert!(
+        result.is_ok(),
+        "Telegram notifier registration should succeed: {:?}",
+        result.err()
+    );
+    let registry = result.unwrap();
+    assert_eq!(registry.len(), 1);
+
+    let notifier = registry
+        .get("telegram-infra")
+        .expect("should be registered");
+    assert_eq!(notifier.name(), "telegram-infra");
+    assert_eq!(notifier.notifier_type(), "telegram");
+}
+
+#[test]
+#[serial]
+fn registry_from_config_propagates_telegram_validation_errors() {
+    let mut notifiers_config = HashMap::new();
+    notifiers_config.insert(
+        "telegram-broken".to_string(),
+        NotifierConfig::Telegram(TelegramNotifierConfig {
+            bot_token: "fake-token".to_string(),
+            chat_ids: vec![],
+            parse_mode: None,
+            disable_notification: None,
+            disable_web_page_preview: None,
+            body_template: None,
+        }),
+    );
+
+    let client = reqwest::Client::new();
+    let result = NotifierRegistry::from_config(&notifiers_config, client, &test_config_dir());
+
+    let errs = result.unwrap_err();
+    assert!(errs.iter().any(|e| e.to_string().contains("chat_ids")));
 }


### PR DESCRIPTION
## Summary

Adds a native `type: telegram` notifier to valerter, alongside the existing Mattermost / Webhook / Email notifiers. Resolves issue #22.

- Uses the Bot API `sendMessage` endpoint, one sequential HTTP call per `chat_id` (Telegram rate-limits at 1 msg/sec/chat so fan-out parallelism would not help).
- `parse_mode: HTML` by default, UTF-8 codepoint-safe truncation at Telegram's 4096 hard limit.
- Full 429 `Retry-After` handling with bounded delay `[1s, 60s]` and a pool of 3 retries shared with 5xx + network errors.
- `bot_token` stored as `SecretString`. Full endpoint URL (which contains the token) is kept in `SecretString` and never logged — `reqwest::Error` is sanitized via `.without_url()` before tracing.
- New Prometheus counter `valerter_alerts_truncated_total{notifier_type}`.

## Validation

- **Tests:** 459 passing (+30 vs 1.0.0) — unit + wiremock integration covering multi-chat fan-out, partial-success, total-failure, 4096 codepoint boundary (incl. 4-byte emoji), 429 header/JSON/fallback chain, token-leak prevention on Debug.
- **Adversarial review:** 3 reviewers (blind hunter, edge-case hunter, acceptance auditor). All findings patched or deferred; deferred work tracked in `_bmad-output/implementation-artifacts/deferred-work.md`.
- **Real prod test:** 2 real alerts delivered to a live Telegram bot from a real VictoriaLogs feed; HTML rendering and metrics clean.
- **Version bump:** 1.0.0 → 1.1.0 in `Cargo.toml`, `Cargo.lock`, CHANGELOG.

## Known limitation (documented in CHANGELOG)

Templates have a single `body` field shared across notifiers. Markdown-flavored bodies (written for Mattermost) render literally in Telegram's HTML mode. Workaround: override `body_template` on the Telegram notifier with HTML-friendly Jinja. A render-pipeline-per-notifier abstraction is planned for 1.2.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 459 passed, 0 failed
- [x] `cargo build --release`
- [x] Live run against production VictoriaLogs feed with real Telegram bot
- [ ] CI green on this PR
- [ ] After merge: tag `v1.1.0` → release workflow publishes x86_64/aarch64 tarballs + `.deb`