### PR TITLE
fix(telegram): guard against empty renders and fix misleading example (#26)

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -97,24 +97,34 @@ defaults:
 # └────────────────────────────────────────────────────────────────────────────┘
 # Message templates using Jinja2 syntax (minijinja).
 #
-# Built-in variables:
-#   rule_name                - Name of the triggered rule
-#   log_timestamp            - Original log timestamp (ISO8601)
-#   log_timestamp_formatted  - Human-readable timestamp (uses defaults.timestamp_timezone)
+# A template entry has two sides:
 #
-# Parser variables:
-#   Any field extracted by the rule's parser (JSON fields or regex named groups)
+# 1. Template variables AVAILABLE on the right-hand side of each line below.
+#    These come from the matched VictoriaLogs event and the runtime:
+#      _msg, _time, _stream                   VL built-in event fields
+#                                             (`_stream_id` is present only on
+#                                              streams configured server-side)
+#      <any parser-extracted field>           JSON field or named regex group
+#      rule_name                              name of the triggered rule
+#      log_timestamp                          event timestamp (ISO8601)
+#      log_timestamp_formatted                human timestamp (defaults.timestamp_timezone)
 #
-# Fields:
-#   title        - Alert title (required)
-#   body         - Alert body, plain text or Markdown (required)
-#   body_html    - HTML version for email (optional, falls back to body)
-#   accent_color - Hex color for visual indicators (optional, e.g., "#ff0000")
+# 2. Template OUTPUT KEYS that you define below (left-hand side). These are
+#    the slots valerter fills and hands off to notifiers:
+#      title         Alert title (required)
+#      body          Alert body, plain text or Markdown (required)
+#      body_html     HTML version for email (optional, falls back to body)
+#      accent_color  Hex color for visual indicators (optional, e.g., "#ff0000")
+#
+# Note: `title` and `body` are NOT variables you can reference on the right.
+# If you want the raw log line, use `{{ _msg }}`.
 
 templates:
   default_alert:
-    title: "{{ title | default('Alert') }}"
-    body: "{{ body }}"
+    title: "{{ rule_name }}"
+    # _msg is the raw log line from VictoriaLogs — works on any event without
+    # needing a parser. Replace with a parsed field for richer templates.
+    body: "{{ _msg }}"
     accent_color: "#3498db"
 
   # ── Example: Severity-based template ───────────────────────────────────────

--- a/src/notify/telegram.rs
+++ b/src/notify/telegram.rs
@@ -10,7 +10,9 @@ use crate::error::{ConfigError, NotifyError};
 use crate::notify::{AlertPayload, Notifier, backoff_delay};
 use async_trait::async_trait;
 use minijinja::{Environment, context};
+use regex::Regex;
 use serde::Serialize;
+use std::sync::LazyLock;
 use std::time::Duration;
 use tracing::Instrument;
 
@@ -100,6 +102,56 @@ fn render_body_template(source: &str, alert: &AlertPayload) -> Result<String, No
         log_timestamp_formatted => &alert.log_timestamp_formatted,
     })
     .map_err(|e| NotifyError::TemplateError(e.to_string()))
+}
+
+/// Strips tags like `<b>`, `<i></i>` from a rendered Telegram HTML body.
+static HTML_TAG_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"<[^>]*>").expect("valid regex"));
+
+/// Cap on title length when wrapping into `<b>…</b>` for the fallback, to stay
+/// under `TELEGRAM_TEXT_MAX_CODEPOINTS` even after HTML-escaping and wrapping.
+const FALLBACK_TITLE_MAX_CODEPOINTS: usize = TELEGRAM_TEXT_MAX_CODEPOINTS - 16;
+
+/// Escape the three characters Telegram's HTML parse_mode treats as markup.
+fn escape_telegram_html(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Return a fallback text + reason when `text` has no visible content, else `None`.
+fn fallback_if_empty(text: &str, alert: &AlertPayload) -> Option<(String, &'static str)> {
+    let reason = if text.is_empty() {
+        "empty_after_render"
+    } else if text.trim().is_empty() {
+        "whitespace_only"
+    } else if HTML_TAG_REGEX.replace_all(text, "").trim().is_empty() {
+        "no_text_content"
+    } else {
+        return None;
+    };
+
+    let fallback = if !alert.message.title.trim().is_empty() {
+        let capped: String = alert
+            .message
+            .title
+            .chars()
+            .take(FALLBACK_TITLE_MAX_CODEPOINTS)
+            .collect();
+        format!("<b>{}</b>", escape_telegram_html(&capped))
+    } else if !alert.rule_name.trim().is_empty() {
+        format!("Alert: {}", escape_telegram_html(&alert.rule_name))
+    } else {
+        "(valerter alert, empty render)".to_string()
+    };
+    Some((fallback, reason))
 }
 
 /// Clamp a parsed retry-after value to the `[RETRY_AFTER_MIN, RETRY_AFTER_MAX]`
@@ -237,7 +289,18 @@ impl TelegramNotifier {
             .as_deref()
             .unwrap_or(DEFAULT_BODY_TEMPLATE);
         let rendered = render_body_template(template, alert)?;
-        Ok(truncate_text(&rendered))
+        let guarded = if let Some((fallback, reason)) = fallback_if_empty(&rendered, alert) {
+            tracing::warn!(
+                rule_name = %alert.rule_name,
+                notifier_name = %self.name,
+                reason = reason,
+                "Telegram body_template rendered empty, applied fallback"
+            );
+            fallback
+        } else {
+            rendered
+        };
+        Ok(truncate_text(&guarded))
     }
 
     /// Send the prepared text to a single chat_id with retry. Returns `Ok` on
@@ -928,4 +991,138 @@ mod tests {
     //    churn in the rest of the module).
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
+
+    // ── fallback_if_empty (#26 empty-render guard) ───────────────────────
+
+    #[test]
+    fn fallback_if_empty_triggers_on_empty() {
+        let alert = sample_alert("", "");
+        let out = fallback_if_empty("", &alert);
+        assert!(out.is_some(), "empty string should trigger fallback");
+        let (_, reason) = out.unwrap();
+        assert_eq!(reason, "empty_after_render");
+    }
+
+    #[test]
+    fn fallback_if_empty_triggers_on_whitespace() {
+        let alert = sample_alert("", "");
+        let out = fallback_if_empty("  \n\t ", &alert);
+        assert!(out.is_some(), "whitespace-only should trigger fallback");
+        let (_, reason) = out.unwrap();
+        assert_eq!(reason, "whitespace_only");
+    }
+
+    #[test]
+    fn fallback_if_empty_triggers_on_html_only() {
+        let alert = sample_alert("", "");
+        let out = fallback_if_empty("<b></b>\n", &alert);
+        assert!(out.is_some(), "html-only should trigger fallback");
+        let (_, reason) = out.unwrap();
+        assert_eq!(reason, "no_text_content");
+    }
+
+    #[test]
+    fn fallback_if_empty_uses_title_when_available() {
+        let alert = sample_alert("Disk full", "");
+        let (text, _) = fallback_if_empty("<b></b>\n", &alert).unwrap();
+        assert_eq!(text, "<b>Disk full</b>");
+    }
+
+    #[test]
+    fn fallback_if_empty_uses_rule_name_as_fallback() {
+        // title is empty → fallback leans on rule_name.
+        let mut alert = sample_alert("", "");
+        alert.rule_name = "nginx-5xx".to_string();
+        let (text, _) = fallback_if_empty("", &alert).unwrap();
+        assert_eq!(text, "Alert: nginx-5xx");
+    }
+
+    #[test]
+    fn fallback_if_empty_uses_literal_when_all_empty() {
+        let mut alert = sample_alert("", "");
+        alert.rule_name = String::new();
+        let (text, _) = fallback_if_empty("", &alert).unwrap();
+        assert_eq!(text, "(valerter alert, empty render)");
+    }
+
+    #[test]
+    fn fallback_escapes_html_specials_in_title() {
+        // Post-review guard: a title containing `<`, `>`, or `&` must not
+        // produce a payload that Telegram's HTML parse_mode would reject.
+        let alert = sample_alert("<script>alert(&amp;)</script>", "");
+        let (text, _) = fallback_if_empty("", &alert).unwrap();
+        assert_eq!(
+            text,
+            "<b>&lt;script&gt;alert(&amp;amp;)&lt;/script&gt;</b>"
+        );
+    }
+
+    #[test]
+    fn fallback_escapes_html_specials_in_rule_name() {
+        let mut alert = sample_alert("", "");
+        alert.rule_name = "a<b & c".to_string();
+        let (text, _) = fallback_if_empty("", &alert).unwrap();
+        assert_eq!(text, "Alert: a&lt;b &amp; c");
+    }
+
+    #[test]
+    fn fallback_caps_long_title_to_stay_under_telegram_limit() {
+        // A pathological 10k-codepoint title must not overflow the
+        // Telegram `text` limit once wrapped in `<b>…</b>`.
+        let long_title: String = "x".repeat(10_000);
+        let alert = sample_alert(&long_title, "");
+        let (text, _) = fallback_if_empty("", &alert).unwrap();
+        assert!(text.chars().count() <= TELEGRAM_TEXT_MAX_CODEPOINTS);
+        assert!(text.starts_with("<b>"));
+        assert!(text.ends_with("</b>"));
+    }
+
+    #[test]
+    fn fallback_if_empty_returns_none_for_non_empty() {
+        let alert = sample_alert("", "");
+        assert!(fallback_if_empty("Hello world", &alert).is_none());
+    }
+
+    #[test]
+    fn fallback_if_empty_returns_none_for_html_with_text() {
+        let alert = sample_alert("", "");
+        assert!(fallback_if_empty("<b>ok</b>", &alert).is_none());
+    }
+
+    // ── prepare_text empty-guard integration ─────────────────────────────
+
+    #[test]
+    fn prepare_text_substitutes_on_empty_render() {
+        // A body_template that renders to literally empty (no vars in context).
+        let client = reqwest::Client::new();
+        let mut cfg = config_with(vec!["-100".to_string()]);
+        cfg.body_template = Some("".to_string());
+        let notifier = TelegramNotifier::from_config("tg", &cfg, client).unwrap();
+        let alert = sample_alert("Disk full", "");
+        let (text, _) = notifier.prepare_text(&alert).unwrap();
+        assert!(!text.trim().is_empty(), "fallback text must not be empty");
+        assert_eq!(text, "<b>Disk full</b>");
+    }
+
+    #[test]
+    fn prepare_text_substitutes_on_html_only_render() {
+        // Reproduces issue #26: default template + empty title/body → "<b></b>\n".
+        let client = reqwest::Client::new();
+        let cfg = config_with(vec!["-100".to_string()]);
+        let notifier = TelegramNotifier::from_config("tg", &cfg, client).unwrap();
+        let mut alert = sample_alert("", "");
+        alert.rule_name = "nginx-5xx".to_string();
+        let (text, _) = notifier.prepare_text(&alert).unwrap();
+        assert_eq!(text, "Alert: nginx-5xx");
+    }
+
+    #[test]
+    fn prepare_text_preserves_non_empty_render() {
+        let client = reqwest::Client::new();
+        let cfg = config_with(vec!["-100".to_string()]);
+        let notifier = TelegramNotifier::from_config("tg", &cfg, client).unwrap();
+        let alert = sample_alert("hello", "world");
+        let (text, _) = notifier.prepare_text(&alert).unwrap();
+        assert_eq!(text, "<b>hello</b>\nworld");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes [#26](https://github.com/fxthiry/Valerter/issues/26). When a user copies the example config pattern (`title: \"{{ title | default('Alert') }}\"` / `body: \"{{ body }}\"`), both templates resolve to empty strings at render time because VictoriaLogs events do not carry `title` / `body` fields. Telegram's `parse_mode: HTML` default then receives a near-empty payload (`<b></b>\n`) and responds HTTP 400 Bad Request. The alert is silently lost.

Two coupled fixes:

- **Runtime guard** in `TelegramNotifier::prepare_text`. If the rendered text is empty, whitespace-only, or contains no text after stripping HTML tags, substitute a priority-ordered fallback and emit a structured `warn!`. Priority: `<b>{title}</b>` if title non-empty, else `Alert: {rule_name}`, else `(valerter alert, empty render)`. Title and rule_name are HTML-escaped and the title is capped to stay under Telegram's 4096 codepoint limit once wrapped.

- **Honest example** in `config/config.example.yaml`. New comment block separates "variables available inside the template" (VL event fields, `rule_name`, `log_timestamp*`) from "template output keys" (`title`, `body`, `body_html`, `accent_color`). The `default_alert` entry switches to `title: "{{ rule_name }}"` and `body: "{{ _msg }}"` so it renders non-empty content out of the box on any VL event.

## Test plan

- [x] `cargo test --lib` — 429 passed (baseline 415 + 14 new: 11 from initial TDD + 3 from review patches)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo run --bin valerter -- --validate -c config/config.example.yaml` — exit 0
- [ ] Smoke-test live once merged with #27 on `release/1.1.1` (prod-test-telegram config + broken template repro)

## Review hints

Adversarial review flagged three issues that are patched in this PR (HTML injection via title/rule_name in the fallback, truncate breaking mid-tag on long titles, em-dash in a user-facing string). See `_bmad-output/implementation-artifacts/deferred-work.md` for seven follow-up items explicitly deferred.

Targeted at `release/1.1.1` so it can be bundled with #27 and validated by the reporter before tagging v1.1.1.