### PR TITLE
refactor!: rename template field body_html to email_body_html (v1.2.0 breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - unreleased
+
+### Breaking changes
+- **Template field `body_html` renamed to `email_body_html`** to reflect that
+  only the email notifier consumes it (Telegram, Mattermost, and webhook always
+  ignored it). Migration: in every template, replace `body_html:` with
+  `email_body_html:`. This applies to templates defined inline in `config.yaml`
+  *and* to any split files under `templates.d/`. Configs using the old name are
+  rejected at load time with a clear error that lists `email_body_html` among
+  the expected fields, so `valerter --validate` will point out every template
+  that needs updating on the first run.
+
+### Fixed
+- **Dotted field access in templates** (issue #25) — fields like
+  `server.hostname` or `http.request.method` can now be referenced directly in
+  Jinja templates using dotted notation, matching the shape users see in log
+  payloads.
+- **Empty Telegram message guard** (issue #26) — Telegram no longer 400s when a
+  rendered body is empty. The notifier now substitutes a fallback string and
+  records the drop reason, and the template documentation explicitly calls out
+  that `body_html` (now `email_body_html`) is email-only so users do not
+  accidentally leave `body` empty.
 
 ## [1.1.0] - 2026-04-15
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -113,9 +113,9 @@ defaults:
 #    the slots valerter fills and hands off to notifiers:
 #      title         Alert title (required)
 #      body          Alert body, plain text or Markdown (required)
-#      body_html     HTML-enriched version used ONLY by the email notifier
+#      email_body_html     HTML-enriched version used ONLY by the email notifier
 #                    (Telegram, Mattermost, and webhook all read `body` and
-#                    ignore `body_html`). To format a Telegram alert, put
+#                    ignore `email_body_html`). To format a Telegram alert, put
 #                    `<b>`/`<i>`/`<code>` inline in `body` — `parse_mode: HTML`
 #                    is Telegram's default.
 #      accent_color  Hex color for visual indicators (optional, e.g., "#ff0000")
@@ -138,7 +138,7 @@ templates:
   #   body: |
   #     **Host:** {{ host }}
   #     **Message:** {{ message }}
-  #   body_html: |
+  #   email_body_html: |
   #     <h2 style="color: red;">{{ title }}</h2>
   #     <p><strong>Host:</strong> {{ host }}</p>
   #     <p>{{ message }}</p>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,7 +157,7 @@ At startup, Valerter validates (in order):
 3. **Template syntax** — All templates compile (minijinja)
 4. **Notifier config** — URLs, credentials, env vars resolve correctly
 5. **Destinations exist** — Rule destinations match notifier names in registry
-6. **Email body_html** — Templates used with email destinations have `body_html`
+6. **Email template body** — Templates used with email destinations have `email_body_html`
 7. **Mattermost channel warning** — Warns if `mattermost_channel` set but no Mattermost notifier in destinations
 
 If any validation fails, Valerter exits immediately with a clear error message.
@@ -211,7 +211,7 @@ tokio::spawn(async { process().unwrap(); }); // Silent crash
 ## Security
 
 - **Config file:** `chmod 600` recommended (secrets in plaintext)
-- **HTML escaping:** `body_html` templates auto-escape variables (XSS prevention)
+- **HTML escaping:** `email_body_html` templates auto-escape variables (XSS prevention)
 - **TLS verification:** Enabled by default (`tls.verify: true`)
 - **No shell execution:** No user input ever reaches a shell
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -188,7 +188,7 @@ templates:
   default_alert:
     title: "{{ title | default('Alert') }}"           # REQUIRED
     body: "{{ body }}"                                 # REQUIRED
-    body_html: "<p>{{ body }}</p>"                     # REQUIRED for email destinations
+    email_body_html: "<p>{{ body }}</p>"                     # REQUIRED for email destinations
     accent_color: "#ff0000"                            # Optional: hex color
 ```
 
@@ -211,9 +211,9 @@ Variables come from the parser output plus built-in fields:
 - Webhook `body_template`
 - Mattermost footer (automatically includes `log_timestamp_formatted`)
 
-### body_html Requirement
+### email_body_html Requirement
 
-**Important:** Templates used with email destinations MUST include `body_html`. Valerter validates this at startup and will fail if missing.
+**Important:** Templates used with email destinations MUST include `email_body_html`. Valerter validates this at startup and will fail if missing.
 
 ## Rules
 
@@ -350,7 +350,7 @@ This checks:
 - Template syntax
 - Notifier configuration
 - Rule destinations exist
-- Email templates have `body_html`
+- Email templates have `email_body_html`
 
 ## See Also
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,7 +94,7 @@ templates:
   default_alert:
     title: "{{ title | default('Alert') }}"
     body: "{{ body }}"
-    body_html: "<p>{{ body }}</p>"
+    email_body_html: "<p>{{ body }}</p>"
 
 rules:
   - name: "error_alert"

--- a/docs/notifiers.md
+++ b/docs/notifiers.md
@@ -15,10 +15,10 @@ Valerter supports multiple notification channels. Configure them in the `notifie
 
 The most flexible notifier - works with any HTTP API.
 
-> **Note about `body_html`** — Webhook reads the outer template's `body`
+> **Note about `email_body_html`** — Webhook reads the outer template's `body`
 > output key (and `title`, `rule_name`, `log_timestamp`, `log_timestamp_formatted`)
-> inside its own `body_template`. It does **not** receive `body_html`;
-> `body_html` is email-only. If your HTTP target needs HTML, put it in `body`
+> inside its own `body_template`. It does **not** receive `email_body_html`;
+> `email_body_html` is email-only. If your HTTP target needs HTML, put it in `body`
 > at the outer template and reference `{{ body }}` from the webhook
 > `body_template`.
 
@@ -185,16 +185,16 @@ notifiers:
 | `starttls` | 587 | STARTTLS upgrade (recommended) |
 | `tls` | 465 | Direct TLS connection |
 
-### body_html Requirement
+### email_body_html Requirement
 
-**Important:** When using email destinations, your message template MUST include `body_html`:
+**Important:** When using email destinations, your message template MUST include `email_body_html`:
 
 ```yaml
 templates:
   my_template:
     title: "{{ title }}"
     body: "{{ body }}"
-    body_html: "<p>{{ body }}</p>"    # REQUIRED for email
+    email_body_html: "<p>{{ body }}</p>"    # REQUIRED for email
 ```
 
 Valerter validates this at startup and will fail if missing.
@@ -225,8 +225,8 @@ notifiers:
 
 Send alerts to Mattermost channels via incoming webhooks.
 
-> **Note about `body_html`** — Mattermost reads the outer template's `body`
-> output key, **not** `body_html`. `body_html` is email-only. Mattermost
+> **Note about `email_body_html`** — Mattermost reads the outer template's `body`
+> output key, **not** `email_body_html`. `email_body_html` is email-only. Mattermost
 > renders Markdown in `body` (`**bold**`, `*italic*`, fenced code blocks,
 > lists, links); write your formatting there.
 
@@ -277,8 +277,8 @@ This helps operators quickly locate the original log entry in VictoriaLogs.
 
 Send alerts to one or more Telegram chats via the Bot API.
 
-> **Note about `body_html`** — Telegram reads the outer template's `body`
-> output key, **not** `body_html`. `body_html` is email-only. For rich
+> **Note about `email_body_html`** — Telegram reads the outer template's `body`
+> output key, **not** `email_body_html`. `email_body_html` is email-only. For rich
 > formatting inside Telegram, put the markup directly in `body` using
 > Telegram's supported HTML subset: `<b>`, `<i>`, `<u>`, `<s>`, `<code>`,
 > `<pre>`, `<blockquote>`, `<a href="…">`, `<span>`, `<tg-spoiler>`.

--- a/examples/cisco-switches/README.md
+++ b/examples/cisco-switches/README.md
@@ -125,7 +125,7 @@ templates:
       ```
       {{ _msg }}
       ```
-    body_html: |
+    email_body_html: |
       <!-- HTML version for email -->
 ```
 

--- a/examples/cisco-switches/config.yaml
+++ b/examples/cisco-switches/config.yaml
@@ -42,7 +42,7 @@ templates:
       ```
       {{ _msg }}
       ```
-    body_html: |
+    email_body_html: |
       <div style="border-left: 4px solid #dc3545; padding-left: 16px; margin-bottom: 16px;">
         <h2 style="color: #dc3545; margin: 0 0 8px 0;">🚨 BPDU Guard Violation</h2>
         <p style="color: #6b7280; margin: 0;">A port has been disabled due to BPDU reception</p>

--- a/scripts/test-notifiers/config-test-notifiers.yaml
+++ b/scripts/test-notifiers/config-test-notifiers.yaml
@@ -17,7 +17,7 @@ templates:
       Alert triggered at {{ timestamp }}
       Host: {{ host | default("unknown") }}
       Message: {{ _msg | default("N/A") }}
-    body_html: |
+    email_body_html: |
       <h2>Alert triggered at {{ timestamp }}</h2>
       <p><strong>Host:</strong> {{ host | default("unknown") }}</p>
       <p><strong>Message:</strong> {{ _msg | default("N/A") }}</p>

--- a/src/config/runtime.rs
+++ b/src/config/runtime.rs
@@ -53,7 +53,7 @@ pub struct CompiledThrottle {
 pub struct CompiledTemplate {
     pub title: String,
     pub body: String,
-    pub body_html: Option<String>,
+    pub email_body_html: Option<String>,
     pub accent_color: Option<String>,
 }
 
@@ -146,7 +146,7 @@ impl Config {
                     CompiledTemplate {
                         title: template.title,
                         body: template.body,
-                        body_html: template.body_html,
+                        email_body_html: template.email_body_html,
                         accent_color: template.accent_color,
                     },
                 )

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -345,7 +345,7 @@ fn make_runtime_config_with_destinations(destinations: Vec<String>) -> RuntimeCo
                 CompiledTemplate {
                     title: "{{ title }}".to_string(),
                     body: "{{ body }}".to_string(),
-                    body_html: None,
+                    email_body_html: None,
                     accent_color: None,
                 },
             );
@@ -451,7 +451,7 @@ fn validate_collects_all_errors() {
                 TemplateConfig {
                     title: "{{ title }}".to_string(),
                     body: "{{ body }}".to_string(),
-                    body_html: None,
+                    email_body_html: None,
                     accent_color: None,
                 },
             );
@@ -528,7 +528,7 @@ fn validate_throttle_key_template() {
                 TemplateConfig {
                     title: "{{ title }}".to_string(),
                     body: "{{ body }}".to_string(),
-                    body_html: None,
+                    email_body_html: None,
                     accent_color: None,
                 },
             );
@@ -591,7 +591,7 @@ fn validate_nonexistent_notify_template_fails() {
                 TemplateConfig {
                     title: "{{ title }}".to_string(),
                     body: "{{ body }}".to_string(),
-                    body_html: None,
+                    email_body_html: None,
                     accent_color: None,
                 },
             );
@@ -710,7 +710,7 @@ fn load_config_with_unknown_notifier_type_fails() {
 }
 
 #[test]
-fn validate_body_html_syntax_error_detected() {
+fn validate_email_body_html_syntax_error_detected() {
     let yaml = r#"
 victorialogs:
   url: http://localhost:9428
@@ -726,7 +726,7 @@ templates:
   test:
     title: "Test"
     body: "Test body"
-    body_html: "{% if unclosed"
+    email_body_html: "{% if unclosed"
 rules: []
 "#;
     let config: Config = serde_yaml::from_str(yaml).unwrap();
@@ -736,11 +736,52 @@ rules: []
     let errors = result.unwrap_err();
     assert!(errors.iter().any(|e| {
         if let crate::error::ConfigError::InvalidTemplate { message, .. } = e {
-            message.contains("body_html")
+            message.contains("email_body_html")
         } else {
             false
         }
     }));
+}
+
+// Regression guard for the v1.2.0 rename of `body_html` → `email_body_html`.
+// The old field name must be rejected at parse time with an error message that
+// mentions both names, so users upgrading from 1.1.x get an actionable hint.
+#[test]
+fn parse_rejects_old_body_html_field_name() {
+    let yaml = r#"
+victorialogs:
+  url: http://localhost:9428
+notifiers:
+  test:
+    type: mattermost
+    webhook_url: "https://example.com/hooks/test"
+defaults:
+  throttle:
+    count: 5
+    window: 1m
+templates:
+  test:
+    title: "Test"
+    body: "Test body"
+    body_html: "<p>legacy</p>"
+rules: []
+"#;
+    let result: Result<Config, _> = serde_yaml::from_str(yaml);
+    assert!(
+        result.is_err(),
+        "YAML with legacy `body_html` field must be rejected at parse time"
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("body_html"),
+        "Error should mention the legacy field name `body_html`, got: {}",
+        err_msg
+    );
+    assert!(
+        err_msg.contains("email_body_html"),
+        "Error should list the new field name `email_body_html` among expected fields, got: {}",
+        err_msg
+    );
 }
 
 #[test]
@@ -925,7 +966,7 @@ fn validate_rule_destinations_collects_all_errors() {
                 CompiledTemplate {
                     title: "{{ title }}".to_string(),
                     body: "{{ body }}".to_string(),
-                    body_html: None,
+                    email_body_html: None,
                     accent_color: None,
                 },
             );

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -157,7 +157,7 @@ pub struct TemplateConfig {
     pub title: String,
     pub body: String,
     #[serde(default)]
-    pub body_html: Option<String>,
+    pub email_body_html: Option<String>,
     #[serde(default)]
     pub accent_color: Option<String>,
 }
@@ -596,12 +596,12 @@ impl Config {
                     message: format!("body: {}", e),
                 });
             }
-            if let Some(body_html) = &template.body_html
-                && let Err(e) = validate_jinja_template(body_html)
+            if let Some(email_body_html) = &template.email_body_html
+                && let Err(e) = validate_jinja_template(email_body_html)
             {
                 errors.push(ConfigError::InvalidTemplate {
                     rule: format!("template:{}", name),
-                    message: format!("body_html: {}", e),
+                    message: format!("email_body_html: {}", e),
                 });
             }
         }
@@ -620,12 +620,12 @@ impl Config {
                     message: format!("body render: {}", e),
                 });
             }
-            if let Some(body_html) = &template.body_html
-                && let Err(e) = super::validation::validate_template_render(body_html)
+            if let Some(email_body_html) = &template.email_body_html
+                && let Err(e) = super::validation::validate_template_render(email_body_html)
             {
                 errors.push(ConfigError::InvalidTemplate {
                     rule: format!("template:{}", name),
-                    message: format!("body_html render: {}", e),
+                    message: format!("email_body_html render: {}", e),
                 });
             }
         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -640,7 +640,7 @@ mod tests {
                     CompiledTemplate {
                         title: "{{ title }}".to_string(),
                         body: "{{ body }}".to_string(),
-                        body_html: None,
+                        email_body_html: None,
                         accent_color: None,
                     },
                 );
@@ -839,7 +839,7 @@ mod tests {
             CompiledTemplate {
                 title: "Alert: {{ _msg }}".to_string(),
                 body: "Log: {{ _msg }}".to_string(),
-                body_html: None,
+                email_body_html: None,
                 accent_color: Some("#ff0000".to_string()),
             },
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,10 +110,10 @@ fn create_notifier_registry(
     Ok(registry)
 }
 
-/// Validate that templates used with email destinations have body_html.
+/// Validate that templates used with email destinations have email_body_html.
 ///
 /// For each enabled rule, if any of its destinations is an email notifier,
-/// the template must have body_html defined. This is a fail-fast validation
+/// the template must have email_body_html defined. This is a fail-fast validation
 /// to prevent runtime errors.
 fn validate_email_templates(
     config: &valerter::config::RuntimeConfig,
@@ -149,9 +149,9 @@ fn validate_email_templates(
         // Get the template name for this rule
         let template_name = &rule.notify.template;
 
-        // Check if template has body_html
+        // Check if template has email_body_html
         if let Some(template) = config.templates.get(template_name)
-            && template.body_html.is_none()
+            && template.email_body_html.is_none()
         {
             let email_dests: Vec<_> = destinations
                 .iter()
@@ -164,7 +164,7 @@ fn validate_email_templates(
                 .collect();
 
             errors.push(format!(
-                "template '{}' requires body_html field when used with email destination{} {} (rule '{}')",
+                "template '{}' requires email_body_html field when used with email destination{} {} (rule '{}')",
                 template_name,
                 if email_dests.len() > 1 { "s" } else { "" },
                 email_dests.iter().map(|s| format!("'{}'", s)).collect::<Vec<_>>().join(", "),
@@ -307,7 +307,7 @@ async fn run(runtime_config: valerter::config::RuntimeConfig) -> Result<()> {
     }
     info!("All rule destinations validated successfully");
 
-    // Validate that templates used with email destinations have body_html (fail-fast)
+    // Validate that templates used with email destinations have email_body_html (fail-fast)
     if let Err(errors) = validate_email_templates(&runtime_config, &registry) {
         for e in &errors {
             error!(error = %e, "Email template validation error");

--- a/src/notify/email.rs
+++ b/src/notify/email.rs
@@ -391,7 +391,7 @@ impl EmailNotifier {
 
     /// Render the body template with alert context.
     ///
-    /// Uses `body_html` from the template engine (already HTML-escaped) if available,
+    /// Uses `email_body_html` from the template engine (already HTML-escaped) if available,
     /// otherwise falls back to `body`. The body is marked as "safe" (pre-escaped) so
     /// the template doesn't need `| safe` filter - this prevents user errors if they
     /// edit the email template and accidentally remove the filter.
@@ -406,10 +406,10 @@ impl EmailNotifier {
             .get_template("body")
             .map_err(|e| NotifyError::TemplateError(format!("body template error: {}", e)))?;
 
-        // Use body_html if available (already HTML-escaped), otherwise fall back to body
+        // Use email_body_html if available (already HTML-escaped), otherwise fall back to body
         let body_content = alert
             .message
-            .body_html
+            .email_body_html
             .as_ref()
             .unwrap_or(&alert.message.body);
 
@@ -795,7 +795,7 @@ mod tests {
             message: RenderedMessage {
                 title: "Test Alert".to_string(),
                 body: "Something happened".to_string(),
-                body_html: None,
+                email_body_html: None,
                 accent_color: Some("#ff0000".to_string()),
             },
             rule_name: rule_name.to_string(),
@@ -1325,9 +1325,9 @@ mod tests {
         );
 
         let mut alert = make_alert_payload("html_test");
-        // body_html is pre-escaped by TemplateEngine, injected with | safe
+        // email_body_html is pre-escaped by TemplateEngine, injected with | safe
         // Using pre-escaped content simulates what TemplateEngine produces
-        alert.message.body_html =
+        alert.message.email_body_html =
             Some("&lt;h1&gt;Alert!&lt;/h1&gt;&lt;p&gt;Something happened&lt;/p&gt;".to_string());
 
         let result = notifier.send(&alert).await;
@@ -1335,10 +1335,10 @@ mod tests {
         assert!(result.is_ok());
         let emails = mock.sent_emails();
         assert_eq!(emails.len(), 1);
-        // body_html content (pre-escaped) is injected directly with | safe
+        // email_body_html content (pre-escaped) is injected directly with | safe
         assert!(
             emails[0].body.contains("&lt;h1&gt;Alert!&lt;"),
-            "Pre-escaped body_html should be in email, got: {}",
+            "Pre-escaped email_body_html should be in email, got: {}",
             emails[0].body
         );
         assert!(

--- a/src/notify/mattermost.rs
+++ b/src/notify/mattermost.rs
@@ -298,7 +298,7 @@ mod tests {
         let message = RenderedMessage {
             title: "Test Alert".to_string(),
             body: "Something happened".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#ff0000".to_string()),
         };
 
@@ -332,7 +332,7 @@ mod tests {
         let message = RenderedMessage {
             title: "Simple Alert".to_string(),
             body: "Body text".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: None,
         };
 
@@ -354,7 +354,7 @@ mod tests {
         let message = RenderedMessage {
             title: "Test".to_string(),
             body: "Body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: None,
         };
 
@@ -380,7 +380,7 @@ mod tests {
         let message = RenderedMessage {
             title: "Test".to_string(),
             body: "Body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#00ff00".to_string()),
         };
 
@@ -411,7 +411,7 @@ mod tests {
         let message = RenderedMessage {
             title: "Test".to_string(),
             body: "Body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: None,
         };
 

--- a/src/notify/telegram.rs
+++ b/src/notify/telegram.rs
@@ -520,7 +520,7 @@ mod tests {
             message: RenderedMessage {
                 title: title.to_string(),
                 body: body.to_string(),
-                body_html: None,
+                email_body_html: None,
                 accent_color: None,
             },
             rule_name: "test_rule".to_string(),

--- a/src/notify/tests.rs
+++ b/src/notify/tests.rs
@@ -23,7 +23,7 @@ fn make_payload(rule_name: &str) -> AlertPayload {
         message: RenderedMessage {
             title: format!("Alert from {}", rule_name),
             body: "Test body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#ff0000".to_string()),
         },
         rule_name: rule_name.to_string(),
@@ -38,7 +38,7 @@ fn make_payload_with_destinations(rule_name: &str, destinations: Vec<String>) ->
         message: RenderedMessage {
             title: format!("Alert from {}", rule_name),
             body: "Test body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#ff0000".to_string()),
         },
         rule_name: rule_name.to_string(),
@@ -636,7 +636,7 @@ fn alert_payload_clone_works() {
         message: RenderedMessage {
             title: "Test".to_string(),
             body: "Body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#ff0000".to_string()),
         },
         rule_name: "my_rule".to_string(),

--- a/src/notify/webhook.rs
+++ b/src/notify/webhook.rs
@@ -383,7 +383,7 @@ mod tests {
             message: RenderedMessage {
                 title: "Test Alert".to_string(),
                 body: "Something happened".to_string(),
-                body_html: None,
+                email_body_html: None,
                 accent_color: Some("#ff0000".to_string()),
             },
             rule_name: rule_name.to_string(),
@@ -653,7 +653,7 @@ mod tests {
             message: RenderedMessage {
                 title: "Simple".to_string(),
                 body: "Body".to_string(),
-                body_html: None,
+                email_body_html: None,
                 accent_color: None,
             },
             rule_name: "simple_rule".to_string(),
@@ -793,7 +793,7 @@ mod tests {
             message: RenderedMessage {
                 title: "Test".to_string(),
                 body: "Body".to_string(),
-                body_html: None,
+                email_body_html: None,
                 accent_color: Some("#ff0000".to_string()),
             },
             rule_name: "test_rule".to_string(),

--- a/src/template.rs
+++ b/src/template.rs
@@ -41,7 +41,7 @@ pub struct RenderedMessage {
     /// Body text of the message (attachment text for Mattermost).
     pub body: String,
     /// Optional HTML body for email notifications (rendered with HTML auto-escape).
-    pub body_html: Option<String>,
+    pub email_body_html: Option<String>,
     /// Optional accent color for visual indicators (hex format: #rrggbb).
     /// Used for email colored dot and Mattermost sidebar color.
     pub accent_color: Option<String>,
@@ -59,7 +59,7 @@ pub struct RenderedMessage {
 pub struct TemplateEngine {
     /// Pre-created Jinja environment (created once, reused for performance).
     env: Environment<'static>,
-    /// Pre-created Jinja environment with HTML auto-escape (for body_html rendering).
+    /// Pre-created Jinja environment with HTML auto-escape (for email_body_html rendering).
     html_env: Environment<'static>,
     /// Compiled templates indexed by name.
     templates: HashMap<String, CompiledTemplate>,
@@ -87,7 +87,7 @@ impl TemplateEngine {
         // This returns empty string instead of erroring on undefined variables
         env.set_undefined_behavior(UndefinedBehavior::Lenient);
 
-        // Pre-create HTML environment for body_html rendering (performance optimization)
+        // Pre-create HTML environment for email_body_html rendering (performance optimization)
         let mut html_env = Environment::new();
         html_env.set_undefined_behavior(UndefinedBehavior::Lenient);
         html_env.set_auto_escape_callback(|_| minijinja::AutoEscape::Html);
@@ -137,9 +137,9 @@ impl TemplateEngine {
         let title = self.render_string(&template.title, fields)?;
         let body = self.render_string(&template.body, fields)?;
 
-        // Render body_html with HTML auto-escape if present
-        let body_html = if let Some(body_html_template) = &template.body_html {
-            Some(self.render_string_html_escaped(body_html_template, fields)?)
+        // Render email_body_html with HTML auto-escape if present
+        let email_body_html = if let Some(email_body_html_template) = &template.email_body_html {
+            Some(self.render_string_html_escaped(email_body_html_template, fields)?)
         } else {
             None
         };
@@ -149,13 +149,13 @@ impl TemplateEngine {
         tracing::trace!(
             title_len = title.len(),
             body_len = body.len(),
-            has_body_html = body_html.is_some(),
+            has_email_body_html = email_body_html.is_some(),
             "Template rendered successfully"
         );
         Ok(RenderedMessage {
             title,
             body,
-            body_html,
+            email_body_html,
             accent_color: template.accent_color.clone(),
         })
     }
@@ -171,7 +171,7 @@ impl TemplateEngine {
     }
 
     /// Render a single template string with HTML auto-escape for security.
-    /// Used for body_html to prevent XSS from log data injected into emails.
+    /// Used for email_body_html to prevent XSS from log data injected into emails.
     fn render_string_html_escaped(
         &self,
         template_str: &str,
@@ -225,7 +225,7 @@ impl TemplateEngine {
                 RenderedMessage {
                     title: format!("[{}] Alert", rule_name),
                     body: format!("Template render failed: {}\n\nCheck logs for details.", e),
-                    body_html: None,
+                    email_body_html: None,
                     accent_color: Some("#ff0000".to_string()), // Red for error
                 }
             }
@@ -251,7 +251,7 @@ mod tests {
         CompiledTemplate {
             title: title.to_string(),
             body: body.to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: None,
         }
     }
@@ -264,7 +264,7 @@ mod tests {
         CompiledTemplate {
             title: title.to_string(),
             body: body.to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: accent_color.map(String::from),
         }
     }
@@ -553,14 +553,14 @@ mod tests {
         let msg1 = RenderedMessage {
             title: "Title".to_string(),
             body: "Body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#000000".to_string()),
         };
 
         let msg2 = RenderedMessage {
             title: "Title".to_string(),
             body: "Body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#000000".to_string()),
         };
 
@@ -630,24 +630,24 @@ mod tests {
     }
 
     // ===================================================================
-    // Task 9: Tests body_html rendering with HTML auto-escape
+    // Task 9: Tests email_body_html rendering with HTML auto-escape
     // ===================================================================
 
-    fn make_template_with_body_html(title: &str, body: &str, body_html: &str) -> CompiledTemplate {
+    fn make_template_with_email_body_html(title: &str, body: &str, email_body_html: &str) -> CompiledTemplate {
         CompiledTemplate {
             title: title.to_string(),
             body: body.to_string(),
-            body_html: Some(body_html.to_string()),
+            email_body_html: Some(email_body_html.to_string()),
             accent_color: None,
         }
     }
 
     #[test]
-    fn render_body_html_is_populated() {
+    fn render_email_body_html_is_populated() {
         let mut templates = HashMap::new();
         templates.insert(
             "email_alert".to_string(),
-            make_template_with_body_html(
+            make_template_with_email_body_html(
                 "Alert: {{ host }}",
                 "Host {{ host }} down",
                 "<p><strong>Host:</strong> {{ host }}</p>",
@@ -661,20 +661,20 @@ mod tests {
 
         assert_eq!(result.title, "Alert: server-01");
         assert_eq!(result.body, "Host server-01 down");
-        assert!(result.body_html.is_some());
+        assert!(result.email_body_html.is_some());
         assert_eq!(
-            result.body_html.unwrap(),
+            result.email_body_html.unwrap(),
             "<p><strong>Host:</strong> server-01</p>"
         );
     }
 
     #[test]
-    fn render_body_html_escapes_html_in_variables() {
+    fn render_email_body_html_escapes_html_in_variables() {
         // AC3: Variables with HTML should be escaped
         let mut templates = HashMap::new();
         templates.insert(
             "email_alert".to_string(),
-            make_template_with_body_html("Alert", "body", "<p>Hostname: {{ hostname }}</p>"),
+            make_template_with_email_body_html("Alert", "body", "<p>Hostname: {{ hostname }}</p>"),
         );
 
         let engine = TemplateEngine::new(templates);
@@ -682,17 +682,17 @@ mod tests {
 
         let result = engine.render("email_alert", &fields).unwrap();
 
-        let body_html = result.body_html.unwrap();
+        let email_body_html = result.email_body_html.unwrap();
         // HTML should be escaped
         assert!(
-            body_html.contains("&lt;script&gt;"),
+            email_body_html.contains("&lt;script&gt;"),
             "Script tags should be escaped: {}",
-            body_html
+            email_body_html
         );
         assert!(
-            !body_html.contains("<script>"),
+            !email_body_html.contains("<script>"),
             "Raw script tags should NOT be present: {}",
-            body_html
+            email_body_html
         );
     }
 
@@ -725,7 +725,7 @@ mod tests {
         let mut templates = HashMap::new();
         templates.insert(
             "my_template".to_string(),
-            make_template_with_body_html(
+            make_template_with_email_body_html(
                 "{{ title }}",
                 "{{ body }}",
                 "<p>{{ hostname }} - {{ nginx.http.request_id }} - {{ nginx.http.method }}</p>",
@@ -745,18 +745,18 @@ mod tests {
         let result = engine.render("my_template", &fields).unwrap();
         assert_eq!(result.title, "T");
         assert_eq!(result.body, "B");
-        let body_html = result.body_html.unwrap();
+        let email_body_html = result.email_body_html.unwrap();
         assert!(
-            body_html.contains("srv-01")
-                && body_html.contains("req-42")
-                && body_html.contains("GET"),
+            email_body_html.contains("srv-01")
+                && email_body_html.contains("req-42")
+                && email_body_html.contains("GET"),
             "expected all dotted fields rendered, got: {}",
-            body_html
+            email_body_html
         );
     }
 
     #[test]
-    fn render_body_html_none_when_template_has_no_body_html() {
+    fn render_email_body_html_none_when_template_has_no_email_body_html() {
         let mut templates = HashMap::new();
         templates.insert(
             "mattermost_alert".to_string(),
@@ -769,8 +769,8 @@ mod tests {
         let result = engine.render("mattermost_alert", &fields).unwrap();
 
         assert!(
-            result.body_html.is_none(),
-            "body_html should be None when template doesn't have it"
+            result.email_body_html.is_none(),
+            "email_body_html should be None when template doesn't have it"
         );
     }
 }

--- a/tests/fixtures/config_email_missing_email_body_html.yaml
+++ b/tests/fixtures/config_email_missing_email_body_html.yaml
@@ -1,4 +1,4 @@
-# Configuration fixture: email notifier with template missing body_html
+# Configuration fixture: email notifier with template missing email_body_html
 # This should fail validation at startup (AC7)
 
 victorialogs:
@@ -13,7 +13,7 @@ templates:
   alert:
     title: "Alert: {{ _msg }}"
     body: "Message: {{ _msg }}"
-    # body_html is missing - should fail validation when used with email
+    # email_body_html is missing - should fail validation when used with email
     accent_color: "#ff0000"
 
 notifiers:

--- a/tests/integration_notify.rs
+++ b/tests/integration_notify.rs
@@ -23,7 +23,7 @@ fn make_payload_with_destinations(rule_name: &str, destinations: Vec<String>) ->
         message: RenderedMessage {
             title: format!("Alert from {}", rule_name),
             body: "Test body content".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#ff0000".to_string()),
         },
         rule_name: rule_name.to_string(),

--- a/tests/integration_validate.rs
+++ b/tests/integration_validate.rs
@@ -150,35 +150,35 @@ fn validate_disabled_rule_with_invalid_regex_exits_failure() {
     );
 }
 
-// Test: email destination with template missing body_html fails startup
+// Test: email destination with template missing email_body_html fails startup
 // This validates AC2: fail-fast validation prevents runtime errors
-// Note: This test runs valerter normally (not --validate) because the body_html
+// Note: This test runs valerter normally (not --validate) because the email_body_html
 // validation happens after config compilation when creating the NotifierRegistry.
 #[test]
-fn validate_email_missing_body_html_exits_failure() {
+fn validate_email_missing_email_body_html_exits_failure() {
     ensure_binary_built();
 
     let output = Command::new(valerter_binary())
         .args(["-c"])
-        .arg(fixture_path("config_email_missing_body_html.yaml"))
+        .arg(fixture_path("config_email_missing_email_body_html.yaml"))
         .output()
         .expect("Failed to run valerter");
 
     assert!(
         !output.status.success(),
-        "valerter should exit with non-zero code for email destination without body_html"
+        "valerter should exit with non-zero code for email destination without email_body_html"
     );
 
     let exit_code = output.status.code().unwrap_or(-1);
     assert_eq!(
         exit_code, 1,
-        "Exit code should be 1 for missing body_html validation failure"
+        "Exit code should be 1 for missing email_body_html validation failure"
     );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("body_html"),
-        "Error message should mention body_html requirement: {}",
+        stderr.contains("email_body_html"),
+        "Error message should mention email_body_html requirement: {}",
         stderr
     );
     assert!(

--- a/tests/smtp_integration.rs
+++ b/tests/smtp_integration.rs
@@ -213,7 +213,7 @@ fn make_alert_payload(rule_name: &str, title: &str, body: &str) -> AlertPayload 
         message: RenderedMessage {
             title: title.to_string(),
             body: body.to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#ff0000".to_string()),
         },
         rule_name: rule_name.to_string(),
@@ -377,8 +377,8 @@ async fn test_send_email_multiple_recipients() {
     );
 }
 
-/// Test sending HTML formatted email with body_html (pre-escaped HTML content).
-/// AC #4: Verify body_html content is included in email
+/// Test sending HTML formatted email with email_body_html (pre-escaped HTML content).
+/// AC #4: Verify email_body_html content is included in email
 #[tokio::test]
 #[ignore] // Requires running Mailhog
 async fn test_send_email_html_format() {
@@ -392,13 +392,13 @@ async fn test_send_email_html_format() {
     // Create notifier with HTML format
     let notifier = create_mailhog_notifier("html-test");
 
-    // body_html is used for pre-rendered HTML content (from TemplateEngine)
-    // This simulates what TemplateEngine produces when rendering body_html
+    // email_body_html is used for pre-rendered HTML content (from TemplateEngine)
+    // This simulates what TemplateEngine produces when rendering email_body_html
     let alert = AlertPayload {
         message: RenderedMessage {
             title: "HTML Alert".to_string(),
             body: "Fallback plain text".to_string(),
-            body_html: Some(
+            email_body_html: Some(
                 "<h1>Alert!</h1><p>Something <strong>important</strong> happened.</p>".to_string(),
             ),
             accent_color: Some("#ff0000".to_string()),
@@ -435,20 +435,20 @@ async fn test_send_email_html_format() {
         content_type
     );
 
-    // Verify HTML content from body_html is in the email body
-    // body_html is injected as safe (pre-escaped) into the default template
-    // Check for content that appears in body_html (may be quoted-printable encoded)
+    // Verify HTML content from email_body_html is in the email body
+    // email_body_html is injected as safe (pre-escaped) into the default template
+    // Check for content that appears in email_body_html (may be quoted-printable encoded)
     assert!(
         message.content.body.contains("Alert!"),
-        "Body should contain the alert content from body_html"
+        "Body should contain the alert content from email_body_html"
     );
     assert!(
         message.content.body.contains("important"),
-        "Body should contain content from body_html"
+        "Body should contain content from email_body_html"
     );
 }
 
-/// Test sending email with plain text body (no body_html).
+/// Test sending email with plain text body (no email_body_html).
 /// AC #4: Verify plain text body is included in HTML email template
 #[tokio::test]
 #[ignore] // Requires running Mailhog
@@ -463,7 +463,7 @@ async fn test_send_email_text_format() {
     // Create notifier - all emails are now HTML with the default template
     let notifier = create_mailhog_notifier("text-test");
 
-    // No body_html - the plain text body will be used in the HTML template
+    // No email_body_html - the plain text body will be used in the HTML template
     let alert = make_alert_payload(
         "text_rule",
         "Plain Text Alert",


### PR DESCRIPTION
## Summary

Breaking rename of the template output field `body_html` → `email_body_html`. Only the email notifier has ever consumed this field; the old name suggested a generic HTML slot that directly misled the user in [#26](https://github.com/fxthiry/Valerter/issues/26). Renaming removes the ambiguity.

Bundled with the fixes for [#25](https://github.com/fxthiry/Valerter/issues/25) and [#26](https://github.com/fxthiry/Valerter/issues/26) (already merged into `release/1.2.0`) to ship as v1.2.0.

## Breaking change

Configs using `body_html:` are rejected at load. Thanks to the pre-existing `#[serde(deny_unknown_fields)]` on `TemplateConfig`, serde produces an actionable error:

```
unknown field `body_html`, expected one of `title`, `body`, `email_body_html`, `accent_color`
```

The expected-fields list names `email_body_html` directly, so `valerter --validate` points users at the migration on the first run. The migration applies equally to inline templates and split `templates.d/` files.

No alias, no custom deserializer — the rename is intentionally nondeniable per project memory *"no backward-compat shims when you can just change the code"*.

## Semantic preservation

Email fallback unchanged: `email_body_html.or(body)`. Telegram / Mattermost / webhook continue to ignore the field (behavior identical — it was always ignored, just less obvious).

## Test plan

- [x] `cargo test --lib` — 444 passed (baseline 443 + 1 new regression test)
- [x] `cargo test` full suite — 498 passed, 22 ignored (SMTP MailHog + doctests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo run --bin valerter -- --validate -c config/config.example.yaml` — exit 0
- [x] Manual regression: YAML with `body_html:` rejected with error mentioning both `body_html` and `email_body_html`
- [ ] Smoke-test live on `release/1.2.0` rc build (reporter validation)

## Review hints

Spec + suggested review order: `_bmad-output/implementation-artifacts/spec-rename-body-html-to-email-body-html.md` (local, not in VCS).

Key entry points:
- `src/config/types.rs:156` — `TemplateConfig` field rename
- `src/template.rs:38` — `RenderedMessage` field rename
- `src/notify/email.rs:409` — consumer logic (preserved semantics)
- `src/config/tests.rs:750` — new regression test for breaking rejection
- `CHANGELOG.md:8` — v1.2.0 entry

Three adversarial reviewers ran on the diff. One raised five false-positive findings that did not reproduce (fixture existence, `deny_unknown_fields` presence, test behavior — all verified green locally). Legitimate findings patched in the same PR: fixture file added to index, CHANGELOG `Unreleased`/`[1.2.0]` duplication resolved, `docs/architecture.md:160` double-email heading fixed, CHANGELOG migration note now explicitly mentions `templates.d/`. Deferred items logged in `deferred-work.md`.