### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - unreleased
+
+### Breaking changes
+- **Template field `body_html` renamed to `email_body_html`** to reflect that
+  only the email notifier consumes it (Telegram, Mattermost, and webhook always
+  ignored it). Migration: in every template, replace `body_html:` with
+  `email_body_html:`. This applies to templates defined inline in `config.yaml`
+  *and* to any split files under `templates.d/`. Configs using the old name are
+  rejected at load time with a clear error that lists `email_body_html` among
+  the expected fields, so `valerter --validate` will point out every template
+  that needs updating on the first run.
+
+### Fixed
+- **Dotted field access in templates** (issue #25) — fields like
+  `server.hostname` or `http.request.method` can now be referenced directly in
+  Jinja templates using dotted notation, matching the shape users see in log
+  payloads.
+- **Empty Telegram message guard** (issue #26) — Telegram no longer 400s when a
+  rendered body is empty. The notifier now substitutes a fallback string and
+  records the drop reason, and the template documentation explicitly calls out
+  that `body_html` (now `email_body_html`) is email-only so users do not
+  accidentally leave `body` empty.
 
 ## [1.1.0] - 2026-04-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "valerter"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "valerter"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 description = "Real-time log alerting for VictoriaLogs"
 license = "Apache-2.0"

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -113,7 +113,11 @@ defaults:
 #    the slots valerter fills and hands off to notifiers:
 #      title         Alert title (required)
 #      body          Alert body, plain text or Markdown (required)
-#      body_html     HTML version for email (optional, falls back to body)
+#      body_html     HTML-enriched version used ONLY by the email notifier
+#                    (Telegram, Mattermost, and webhook all read `body` and
+#                    ignore `body_html`). To format a Telegram alert, put
+#                    `<b>`/`<i>`/`<code>` inline in `body` — `parse_mode: HTML`
+#                    is Telegram's default.
 #      accent_color  Hex color for visual indicators (optional, e.g., "#ff0000")
 #
 # Note: `title` and `body` are NOT variables you can reference on the right.

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -97,24 +97,34 @@ defaults:
 # └────────────────────────────────────────────────────────────────────────────┘
 # Message templates using Jinja2 syntax (minijinja).
 #
-# Built-in variables:
-#   rule_name                - Name of the triggered rule
-#   log_timestamp            - Original log timestamp (ISO8601)
-#   log_timestamp_formatted  - Human-readable timestamp (uses defaults.timestamp_timezone)
+# A template entry has two sides:
 #
-# Parser variables:
-#   Any field extracted by the rule's parser (JSON fields or regex named groups)
+# 1. Template variables AVAILABLE on the right-hand side of each line below.
+#    These come from the matched VictoriaLogs event and the runtime:
+#      _msg, _time, _stream                   VL built-in event fields
+#                                             (`_stream_id` is present only on
+#                                              streams configured server-side)
+#      <any parser-extracted field>           JSON field or named regex group
+#      rule_name                              name of the triggered rule
+#      log_timestamp                          event timestamp (ISO8601)
+#      log_timestamp_formatted                human timestamp (defaults.timestamp_timezone)
 #
-# Fields:
-#   title        - Alert title (required)
-#   body         - Alert body, plain text or Markdown (required)
-#   body_html    - HTML version for email (optional, falls back to body)
-#   accent_color - Hex color for visual indicators (optional, e.g., "#ff0000")
+# 2. Template OUTPUT KEYS that you define below (left-hand side). These are
+#    the slots valerter fills and hands off to notifiers:
+#      title         Alert title (required)
+#      body          Alert body, plain text or Markdown (required)
+#      body_html     HTML version for email (optional, falls back to body)
+#      accent_color  Hex color for visual indicators (optional, e.g., "#ff0000")
+#
+# Note: `title` and `body` are NOT variables you can reference on the right.
+# If you want the raw log line, use `{{ _msg }}`.
 
 templates:
   default_alert:
-    title: "{{ title | default('Alert') }}"
-    body: "{{ body }}"
+    title: "{{ rule_name }}"
+    # _msg is the raw log line from VictoriaLogs — works on any event without
+    # needing a parser. Replace with a parsed field for richer templates.
+    body: "{{ _msg }}"
     accent_color: "#3498db"
 
   # ── Example: Severity-based template ───────────────────────────────────────

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -113,9 +113,9 @@ defaults:
 #    the slots valerter fills and hands off to notifiers:
 #      title         Alert title (required)
 #      body          Alert body, plain text or Markdown (required)
-#      body_html     HTML-enriched version used ONLY by the email notifier
+#      email_body_html     HTML-enriched version used ONLY by the email notifier
 #                    (Telegram, Mattermost, and webhook all read `body` and
-#                    ignore `body_html`). To format a Telegram alert, put
+#                    ignore `email_body_html`). To format a Telegram alert, put
 #                    `<b>`/`<i>`/`<code>` inline in `body` — `parse_mode: HTML`
 #                    is Telegram's default.
 #      accent_color  Hex color for visual indicators (optional, e.g., "#ff0000")
@@ -138,7 +138,7 @@ templates:
   #   body: |
   #     **Host:** {{ host }}
   #     **Message:** {{ message }}
-  #   body_html: |
+  #   email_body_html: |
   #     <h2 style="color: red;">{{ title }}</h2>
   #     <p><strong>Host:</strong> {{ host }}</p>
   #     <p>{{ message }}</p>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,7 +157,7 @@ At startup, Valerter validates (in order):
 3. **Template syntax** — All templates compile (minijinja)
 4. **Notifier config** — URLs, credentials, env vars resolve correctly
 5. **Destinations exist** — Rule destinations match notifier names in registry
-6. **Email body_html** — Templates used with email destinations have `body_html`
+6. **Email template body** — Templates used with email destinations have `email_body_html`
 7. **Mattermost channel warning** — Warns if `mattermost_channel` set but no Mattermost notifier in destinations
 
 If any validation fails, Valerter exits immediately with a clear error message.
@@ -211,7 +211,7 @@ tokio::spawn(async { process().unwrap(); }); // Silent crash
 ## Security
 
 - **Config file:** `chmod 600` recommended (secrets in plaintext)
-- **HTML escaping:** `body_html` templates auto-escape variables (XSS prevention)
+- **HTML escaping:** `email_body_html` templates auto-escape variables (XSS prevention)
 - **TLS verification:** Enabled by default (`tls.verify: true`)
 - **No shell execution:** No user input ever reaches a shell
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -188,7 +188,7 @@ templates:
   default_alert:
     title: "{{ title | default('Alert') }}"           # REQUIRED
     body: "{{ body }}"                                 # REQUIRED
-    body_html: "<p>{{ body }}</p>"                     # REQUIRED for email destinations
+    email_body_html: "<p>{{ body }}</p>"                     # REQUIRED for email destinations
     accent_color: "#ff0000"                            # Optional: hex color
 ```
 
@@ -211,9 +211,9 @@ Variables come from the parser output plus built-in fields:
 - Webhook `body_template`
 - Mattermost footer (automatically includes `log_timestamp_formatted`)
 
-### body_html Requirement
+### email_body_html Requirement
 
-**Important:** Templates used with email destinations MUST include `body_html`. Valerter validates this at startup and will fail if missing.
+**Important:** Templates used with email destinations MUST include `email_body_html`. Valerter validates this at startup and will fail if missing.
 
 ## Rules
 
@@ -350,7 +350,7 @@ This checks:
 - Template syntax
 - Notifier configuration
 - Rule destinations exist
-- Email templates have `body_html`
+- Email templates have `email_body_html`
 
 ## See Also
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,7 +94,7 @@ templates:
   default_alert:
     title: "{{ title | default('Alert') }}"
     body: "{{ body }}"
-    body_html: "<p>{{ body }}</p>"
+    email_body_html: "<p>{{ body }}</p>"
 
 rules:
   - name: "error_alert"

--- a/docs/notifiers.md
+++ b/docs/notifiers.md
@@ -15,10 +15,10 @@ Valerter supports multiple notification channels. Configure them in the `notifie
 
 The most flexible notifier - works with any HTTP API.
 
-> **Note about `body_html`** — Webhook reads the outer template's `body`
+> **Note about `email_body_html`** — Webhook reads the outer template's `body`
 > output key (and `title`, `rule_name`, `log_timestamp`, `log_timestamp_formatted`)
-> inside its own `body_template`. It does **not** receive `body_html`;
-> `body_html` is email-only. If your HTTP target needs HTML, put it in `body`
+> inside its own `body_template`. It does **not** receive `email_body_html`;
+> `email_body_html` is email-only. If your HTTP target needs HTML, put it in `body`
 > at the outer template and reference `{{ body }}` from the webhook
 > `body_template`.
 
@@ -185,16 +185,16 @@ notifiers:
 | `starttls` | 587 | STARTTLS upgrade (recommended) |
 | `tls` | 465 | Direct TLS connection |
 
-### body_html Requirement
+### email_body_html Requirement
 
-**Important:** When using email destinations, your message template MUST include `body_html`:
+**Important:** When using email destinations, your message template MUST include `email_body_html`:
 
 ```yaml
 templates:
   my_template:
     title: "{{ title }}"
     body: "{{ body }}"
-    body_html: "<p>{{ body }}</p>"    # REQUIRED for email
+    email_body_html: "<p>{{ body }}</p>"    # REQUIRED for email
 ```
 
 Valerter validates this at startup and will fail if missing.
@@ -225,8 +225,8 @@ notifiers:
 
 Send alerts to Mattermost channels via incoming webhooks.
 
-> **Note about `body_html`** — Mattermost reads the outer template's `body`
-> output key, **not** `body_html`. `body_html` is email-only. Mattermost
+> **Note about `email_body_html`** — Mattermost reads the outer template's `body`
+> output key, **not** `email_body_html`. `email_body_html` is email-only. Mattermost
 > renders Markdown in `body` (`**bold**`, `*italic*`, fenced code blocks,
 > lists, links); write your formatting there.
 
@@ -277,8 +277,8 @@ This helps operators quickly locate the original log entry in VictoriaLogs.
 
 Send alerts to one or more Telegram chats via the Bot API.
 
-> **Note about `body_html`** — Telegram reads the outer template's `body`
-> output key, **not** `body_html`. `body_html` is email-only. For rich
+> **Note about `email_body_html`** — Telegram reads the outer template's `body`
+> output key, **not** `email_body_html`. `email_body_html` is email-only. For rich
 > formatting inside Telegram, put the markup directly in `body` using
 > Telegram's supported HTML subset: `<b>`, `<i>`, `<u>`, `<s>`, `<code>`,
 > `<pre>`, `<blockquote>`, `<a href="…">`, `<span>`, `<tg-spoiler>`.

--- a/docs/notifiers.md
+++ b/docs/notifiers.md
@@ -15,6 +15,13 @@ Valerter supports multiple notification channels. Configure them in the `notifie
 
 The most flexible notifier - works with any HTTP API.
 
+> **Note about `body_html`** — Webhook reads the outer template's `body`
+> output key (and `title`, `rule_name`, `log_timestamp`, `log_timestamp_formatted`)
+> inside its own `body_template`. It does **not** receive `body_html`;
+> `body_html` is email-only. If your HTTP target needs HTML, put it in `body`
+> at the outer template and reference `{{ body }}` from the webhook
+> `body_template`.
+
 ### Configuration
 
 ```yaml
@@ -218,6 +225,11 @@ notifiers:
 
 Send alerts to Mattermost channels via incoming webhooks.
 
+> **Note about `body_html`** — Mattermost reads the outer template's `body`
+> output key, **not** `body_html`. `body_html` is email-only. Mattermost
+> renders Markdown in `body` (`**bold**`, `*italic*`, fenced code blocks,
+> lists, links); write your formatting there.
+
 ### Configuration
 
 ```yaml
@@ -264,6 +276,13 @@ This helps operators quickly locate the original log entry in VictoriaLogs.
 ## Telegram
 
 Send alerts to one or more Telegram chats via the Bot API.
+
+> **Note about `body_html`** — Telegram reads the outer template's `body`
+> output key, **not** `body_html`. `body_html` is email-only. For rich
+> formatting inside Telegram, put the markup directly in `body` using
+> Telegram's supported HTML subset: `<b>`, `<i>`, `<u>`, `<s>`, `<code>`,
+> `<pre>`, `<blockquote>`, `<a href="…">`, `<span>`, `<tg-spoiler>`.
+> Keep `parse_mode: HTML` (the default) so the Bot API interprets those tags.
 
 ### Prerequisites
 

--- a/examples/cisco-switches/README.md
+++ b/examples/cisco-switches/README.md
@@ -125,7 +125,7 @@ templates:
       ```
       {{ _msg }}
       ```
-    body_html: |
+    email_body_html: |
       <!-- HTML version for email -->
 ```
 

--- a/examples/cisco-switches/config.yaml
+++ b/examples/cisco-switches/config.yaml
@@ -42,7 +42,7 @@ templates:
       ```
       {{ _msg }}
       ```
-    body_html: |
+    email_body_html: |
       <div style="border-left: 4px solid #dc3545; padding-left: 16px; margin-bottom: 16px;">
         <h2 style="color: #dc3545; margin: 0 0 8px 0;">🚨 BPDU Guard Violation</h2>
         <p style="color: #6b7280; margin: 0;">A port has been disabled due to BPDU reception</p>

--- a/scripts/test-notifiers/config-test-notifiers.yaml
+++ b/scripts/test-notifiers/config-test-notifiers.yaml
@@ -17,7 +17,7 @@ templates:
       Alert triggered at {{ timestamp }}
       Host: {{ host | default("unknown") }}
       Message: {{ _msg | default("N/A") }}
-    body_html: |
+    email_body_html: |
       <h2>Alert triggered at {{ timestamp }}</h2>
       <p><strong>Host:</strong> {{ host | default("unknown") }}</p>
       <p><strong>Message:</strong> {{ _msg | default("N/A") }}</p>

--- a/src/config/runtime.rs
+++ b/src/config/runtime.rs
@@ -53,7 +53,7 @@ pub struct CompiledThrottle {
 pub struct CompiledTemplate {
     pub title: String,
     pub body: String,
-    pub body_html: Option<String>,
+    pub email_body_html: Option<String>,
     pub accent_color: Option<String>,
 }
 
@@ -146,7 +146,7 @@ impl Config {
                     CompiledTemplate {
                         title: template.title,
                         body: template.body,
-                        body_html: template.body_html,
+                        email_body_html: template.email_body_html,
                         accent_color: template.accent_color,
                     },
                 )

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -345,7 +345,7 @@ fn make_runtime_config_with_destinations(destinations: Vec<String>) -> RuntimeCo
                 CompiledTemplate {
                     title: "{{ title }}".to_string(),
                     body: "{{ body }}".to_string(),
-                    body_html: None,
+                    email_body_html: None,
                     accent_color: None,
                 },
             );
@@ -451,7 +451,7 @@ fn validate_collects_all_errors() {
                 TemplateConfig {
                     title: "{{ title }}".to_string(),
                     body: "{{ body }}".to_string(),
-                    body_html: None,
+                    email_body_html: None,
                     accent_color: None,
                 },
             );
@@ -528,7 +528,7 @@ fn validate_throttle_key_template() {
                 TemplateConfig {
                     title: "{{ title }}".to_string(),
                     body: "{{ body }}".to_string(),
-                    body_html: None,
+                    email_body_html: None,
                     accent_color: None,
                 },
             );
@@ -591,7 +591,7 @@ fn validate_nonexistent_notify_template_fails() {
                 TemplateConfig {
                     title: "{{ title }}".to_string(),
                     body: "{{ body }}".to_string(),
-                    body_html: None,
+                    email_body_html: None,
                     accent_color: None,
                 },
             );
@@ -710,7 +710,7 @@ fn load_config_with_unknown_notifier_type_fails() {
 }
 
 #[test]
-fn validate_body_html_syntax_error_detected() {
+fn validate_email_body_html_syntax_error_detected() {
     let yaml = r#"
 victorialogs:
   url: http://localhost:9428
@@ -726,7 +726,7 @@ templates:
   test:
     title: "Test"
     body: "Test body"
-    body_html: "{% if unclosed"
+    email_body_html: "{% if unclosed"
 rules: []
 "#;
     let config: Config = serde_yaml::from_str(yaml).unwrap();
@@ -736,11 +736,52 @@ rules: []
     let errors = result.unwrap_err();
     assert!(errors.iter().any(|e| {
         if let crate::error::ConfigError::InvalidTemplate { message, .. } = e {
-            message.contains("body_html")
+            message.contains("email_body_html")
         } else {
             false
         }
     }));
+}
+
+// Regression guard for the v1.2.0 rename of `body_html` → `email_body_html`.
+// The old field name must be rejected at parse time with an error message that
+// mentions both names, so users upgrading from 1.1.x get an actionable hint.
+#[test]
+fn parse_rejects_old_body_html_field_name() {
+    let yaml = r#"
+victorialogs:
+  url: http://localhost:9428
+notifiers:
+  test:
+    type: mattermost
+    webhook_url: "https://example.com/hooks/test"
+defaults:
+  throttle:
+    count: 5
+    window: 1m
+templates:
+  test:
+    title: "Test"
+    body: "Test body"
+    body_html: "<p>legacy</p>"
+rules: []
+"#;
+    let result: Result<Config, _> = serde_yaml::from_str(yaml);
+    assert!(
+        result.is_err(),
+        "YAML with legacy `body_html` field must be rejected at parse time"
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("body_html"),
+        "Error should mention the legacy field name `body_html`, got: {}",
+        err_msg
+    );
+    assert!(
+        err_msg.contains("email_body_html"),
+        "Error should list the new field name `email_body_html` among expected fields, got: {}",
+        err_msg
+    );
 }
 
 #[test]
@@ -925,7 +966,7 @@ fn validate_rule_destinations_collects_all_errors() {
                 CompiledTemplate {
                     title: "{{ title }}".to_string(),
                     body: "{{ body }}".to_string(),
-                    body_html: None,
+                    email_body_html: None,
                     accent_color: None,
                 },
             );

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -157,7 +157,7 @@ pub struct TemplateConfig {
     pub title: String,
     pub body: String,
     #[serde(default)]
-    pub body_html: Option<String>,
+    pub email_body_html: Option<String>,
     #[serde(default)]
     pub accent_color: Option<String>,
 }
@@ -596,12 +596,12 @@ impl Config {
                     message: format!("body: {}", e),
                 });
             }
-            if let Some(body_html) = &template.body_html
-                && let Err(e) = validate_jinja_template(body_html)
+            if let Some(email_body_html) = &template.email_body_html
+                && let Err(e) = validate_jinja_template(email_body_html)
             {
                 errors.push(ConfigError::InvalidTemplate {
                     rule: format!("template:{}", name),
-                    message: format!("body_html: {}", e),
+                    message: format!("email_body_html: {}", e),
                 });
             }
         }
@@ -620,12 +620,12 @@ impl Config {
                     message: format!("body render: {}", e),
                 });
             }
-            if let Some(body_html) = &template.body_html
-                && let Err(e) = super::validation::validate_template_render(body_html)
+            if let Some(email_body_html) = &template.email_body_html
+                && let Err(e) = super::validation::validate_template_render(email_body_html)
             {
                 errors.push(ConfigError::InvalidTemplate {
                     rule: format!("template:{}", name),
-                    message: format!("body_html render: {}", e),
+                    message: format!("email_body_html render: {}", e),
                 });
             }
         }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -170,8 +170,7 @@ mod tests {
         // would silently skip this `{% if %}` body (falsy undefined) and miss
         // the unknown filter. TruthyChainable keeps is_true() = true so the
         // body is walked.
-        let result =
-            validate_template_render("{% if a.b %}{{ x | nosuchfilter }}{% endif %}");
+        let result = validate_template_render("{% if a.b %}{{ x | nosuchfilter }}{% endif %}");
         assert!(
             result.is_err(),
             "unknown filter inside if-block should still be caught"
@@ -189,8 +188,7 @@ mod tests {
     fn validate_template_render_allows_for_loop_over_undefined() {
         // Regression guard: initial TruthyChainable had NonEnumerable + Plain repr,
         // which errored on `{% for %}` even though Lenient + json!({}) didn't.
-        let result =
-            validate_template_render("{% for x in items %}{{ x }}{% endfor %}");
+        let result = validate_template_render("{% for x in items %}{{ x }}{% endfor %}");
         assert!(
             result.is_ok(),
             "for-loop over undefined should validate cleanly: {:?}",

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1,8 +1,45 @@
 //! Template and color validation utilities.
 
+use minijinja::value::{Enumerator, Object, ObjectRepr, Value};
 use minijinja::{Environment, UndefinedBehavior};
 use regex::Regex;
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
+
+/// Sentinel context object used during template validation.
+///
+/// Issue #25: validating templates that reference dotted VictoriaLogs fields
+/// (`{{ nginx.http.request_id }}`) used to fail because chained attribute access
+/// against an empty `json!({})` returned `undefined` instead of another value.
+///
+/// `TruthyChainable` returns itself on every attribute access (so chains never
+/// hit `undefined`), is always truthy (so `{% if x.y %}` walks the body and
+/// validates filters/syntax inside), stringifies as empty, and iterates as an
+/// empty sequence (so `{% for x in tc %}` and `{{ tc | length }}` do not error
+/// — matching the prior `Lenient + json!({})` behaviour).
+#[derive(Debug)]
+struct TruthyChainable;
+
+impl Object for TruthyChainable {
+    fn repr(self: &Arc<Self>) -> ObjectRepr {
+        ObjectRepr::Seq
+    }
+
+    fn get_value(self: &Arc<Self>, _key: &Value) -> Option<Value> {
+        Some(Value::from_dyn_object(self.clone()))
+    }
+
+    fn enumerate(self: &Arc<Self>) -> Enumerator {
+        Enumerator::Empty
+    }
+
+    fn is_true(self: &Arc<Self>) -> bool {
+        true
+    }
+
+    fn render(self: &Arc<Self>, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
+    }
+}
 
 /// Validates Jinja template syntax.
 pub(crate) fn validate_jinja_template(source: &str) -> Result<(), String> {
@@ -26,7 +63,7 @@ pub fn validate_template_render(source: &str) -> Result<(), String> {
     let tmpl = env
         .get_template("_render_test")
         .map_err(|e| e.to_string())?;
-    tmpl.render(serde_json::json!({}))
+    tmpl.render(Value::from_object(TruthyChainable))
         .map_err(|e| e.to_string())?;
 
     Ok(())
@@ -109,5 +146,65 @@ mod tests {
     fn validate_jinja_template_accepts_valid_syntax() {
         let result = validate_jinja_template("{{ name }} - {% if x %}yes{% endif %}");
         assert!(result.is_ok());
+    }
+
+    // ============================================================
+    // Issue #25: dotted-field template validation
+    // ============================================================
+
+    #[test]
+    fn validate_template_render_accepts_chained_undefined() {
+        // The bug: `{{ a.b.c }}` against `json!({})` returned "undefined value".
+        // With TruthyChainable, chained access on undefined should resolve.
+        let result = validate_template_render("{{ a.b.c }}");
+        assert!(
+            result.is_ok(),
+            "chained undefined access should validate cleanly: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn validate_template_render_still_catches_filter_in_if_block() {
+        // Regression guard: a straight switch to UndefinedBehavior::Chainable
+        // would silently skip this `{% if %}` body (falsy undefined) and miss
+        // the unknown filter. TruthyChainable keeps is_true() = true so the
+        // body is walked.
+        let result =
+            validate_template_render("{% if a.b %}{{ x | nosuchfilter }}{% endif %}");
+        assert!(
+            result.is_err(),
+            "unknown filter inside if-block should still be caught"
+        );
+        assert!(result.unwrap_err().contains("nosuchfilter"));
+    }
+
+    #[test]
+    fn validate_template_render_catches_syntax_errors() {
+        let result = validate_template_render("{{ foo.");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_template_render_allows_for_loop_over_undefined() {
+        // Regression guard: initial TruthyChainable had NonEnumerable + Plain repr,
+        // which errored on `{% for %}` even though Lenient + json!({}) didn't.
+        let result =
+            validate_template_render("{% for x in items %}{{ x }}{% endfor %}");
+        assert!(
+            result.is_ok(),
+            "for-loop over undefined should validate cleanly: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn validate_template_render_allows_length_on_undefined() {
+        let result = validate_template_render("{{ (items | length) > 0 }}");
+        assert!(
+            result.is_ok(),
+            "length on undefined should validate cleanly: {:?}",
+            result
+        );
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -640,7 +640,7 @@ mod tests {
                     CompiledTemplate {
                         title: "{{ title }}".to_string(),
                         body: "{{ body }}".to_string(),
-                        body_html: None,
+                        email_body_html: None,
                         accent_color: None,
                     },
                 );
@@ -839,7 +839,7 @@ mod tests {
             CompiledTemplate {
                 title: "Alert: {{ _msg }}".to_string(),
                 body: "Log: {{ _msg }}".to_string(),
-                body_html: None,
+                email_body_html: None,
                 accent_color: Some("#ff0000".to_string()),
             },
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,10 +110,10 @@ fn create_notifier_registry(
     Ok(registry)
 }
 
-/// Validate that templates used with email destinations have body_html.
+/// Validate that templates used with email destinations have email_body_html.
 ///
 /// For each enabled rule, if any of its destinations is an email notifier,
-/// the template must have body_html defined. This is a fail-fast validation
+/// the template must have email_body_html defined. This is a fail-fast validation
 /// to prevent runtime errors.
 fn validate_email_templates(
     config: &valerter::config::RuntimeConfig,
@@ -149,9 +149,9 @@ fn validate_email_templates(
         // Get the template name for this rule
         let template_name = &rule.notify.template;
 
-        // Check if template has body_html
+        // Check if template has email_body_html
         if let Some(template) = config.templates.get(template_name)
-            && template.body_html.is_none()
+            && template.email_body_html.is_none()
         {
             let email_dests: Vec<_> = destinations
                 .iter()
@@ -164,7 +164,7 @@ fn validate_email_templates(
                 .collect();
 
             errors.push(format!(
-                "template '{}' requires body_html field when used with email destination{} {} (rule '{}')",
+                "template '{}' requires email_body_html field when used with email destination{} {} (rule '{}')",
                 template_name,
                 if email_dests.len() > 1 { "s" } else { "" },
                 email_dests.iter().map(|s| format!("'{}'", s)).collect::<Vec<_>>().join(", "),
@@ -307,7 +307,7 @@ async fn run(runtime_config: valerter::config::RuntimeConfig) -> Result<()> {
     }
     info!("All rule destinations validated successfully");
 
-    // Validate that templates used with email destinations have body_html (fail-fast)
+    // Validate that templates used with email destinations have email_body_html (fail-fast)
     if let Err(errors) = validate_email_templates(&runtime_config, &registry) {
         for e in &errors {
             error!(error = %e, "Email template validation error");

--- a/src/notify/email.rs
+++ b/src/notify/email.rs
@@ -391,7 +391,7 @@ impl EmailNotifier {
 
     /// Render the body template with alert context.
     ///
-    /// Uses `body_html` from the template engine (already HTML-escaped) if available,
+    /// Uses `email_body_html` from the template engine (already HTML-escaped) if available,
     /// otherwise falls back to `body`. The body is marked as "safe" (pre-escaped) so
     /// the template doesn't need `| safe` filter - this prevents user errors if they
     /// edit the email template and accidentally remove the filter.
@@ -406,10 +406,10 @@ impl EmailNotifier {
             .get_template("body")
             .map_err(|e| NotifyError::TemplateError(format!("body template error: {}", e)))?;
 
-        // Use body_html if available (already HTML-escaped), otherwise fall back to body
+        // Use email_body_html if available (already HTML-escaped), otherwise fall back to body
         let body_content = alert
             .message
-            .body_html
+            .email_body_html
             .as_ref()
             .unwrap_or(&alert.message.body);
 
@@ -795,7 +795,7 @@ mod tests {
             message: RenderedMessage {
                 title: "Test Alert".to_string(),
                 body: "Something happened".to_string(),
-                body_html: None,
+                email_body_html: None,
                 accent_color: Some("#ff0000".to_string()),
             },
             rule_name: rule_name.to_string(),
@@ -1325,9 +1325,9 @@ mod tests {
         );
 
         let mut alert = make_alert_payload("html_test");
-        // body_html is pre-escaped by TemplateEngine, injected with | safe
+        // email_body_html is pre-escaped by TemplateEngine, injected with | safe
         // Using pre-escaped content simulates what TemplateEngine produces
-        alert.message.body_html =
+        alert.message.email_body_html =
             Some("&lt;h1&gt;Alert!&lt;/h1&gt;&lt;p&gt;Something happened&lt;/p&gt;".to_string());
 
         let result = notifier.send(&alert).await;
@@ -1335,10 +1335,10 @@ mod tests {
         assert!(result.is_ok());
         let emails = mock.sent_emails();
         assert_eq!(emails.len(), 1);
-        // body_html content (pre-escaped) is injected directly with | safe
+        // email_body_html content (pre-escaped) is injected directly with | safe
         assert!(
             emails[0].body.contains("&lt;h1&gt;Alert!&lt;"),
-            "Pre-escaped body_html should be in email, got: {}",
+            "Pre-escaped email_body_html should be in email, got: {}",
             emails[0].body
         );
         assert!(

--- a/src/notify/mattermost.rs
+++ b/src/notify/mattermost.rs
@@ -298,7 +298,7 @@ mod tests {
         let message = RenderedMessage {
             title: "Test Alert".to_string(),
             body: "Something happened".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#ff0000".to_string()),
         };
 
@@ -332,7 +332,7 @@ mod tests {
         let message = RenderedMessage {
             title: "Simple Alert".to_string(),
             body: "Body text".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: None,
         };
 
@@ -354,7 +354,7 @@ mod tests {
         let message = RenderedMessage {
             title: "Test".to_string(),
             body: "Body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: None,
         };
 
@@ -380,7 +380,7 @@ mod tests {
         let message = RenderedMessage {
             title: "Test".to_string(),
             body: "Body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#00ff00".to_string()),
         };
 
@@ -411,7 +411,7 @@ mod tests {
         let message = RenderedMessage {
             title: "Test".to_string(),
             body: "Body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: None,
         };
 

--- a/src/notify/telegram.rs
+++ b/src/notify/telegram.rs
@@ -1051,10 +1051,7 @@ mod tests {
         // produce a payload that Telegram's HTML parse_mode would reject.
         let alert = sample_alert("<script>alert(&amp;)</script>", "");
         let (text, _) = fallback_if_empty("", &alert).unwrap();
-        assert_eq!(
-            text,
-            "<b>&lt;script&gt;alert(&amp;amp;)&lt;/script&gt;</b>"
-        );
+        assert_eq!(text, "<b>&lt;script&gt;alert(&amp;amp;)&lt;/script&gt;</b>");
     }
 
     #[test]

--- a/src/notify/telegram.rs
+++ b/src/notify/telegram.rs
@@ -520,7 +520,7 @@ mod tests {
             message: RenderedMessage {
                 title: title.to_string(),
                 body: body.to_string(),
-                body_html: None,
+                email_body_html: None,
                 accent_color: None,
             },
             rule_name: "test_rule".to_string(),

--- a/src/notify/telegram.rs
+++ b/src/notify/telegram.rs
@@ -10,7 +10,9 @@ use crate::error::{ConfigError, NotifyError};
 use crate::notify::{AlertPayload, Notifier, backoff_delay};
 use async_trait::async_trait;
 use minijinja::{Environment, context};
+use regex::Regex;
 use serde::Serialize;
+use std::sync::LazyLock;
 use std::time::Duration;
 use tracing::Instrument;
 
@@ -100,6 +102,56 @@ fn render_body_template(source: &str, alert: &AlertPayload) -> Result<String, No
         log_timestamp_formatted => &alert.log_timestamp_formatted,
     })
     .map_err(|e| NotifyError::TemplateError(e.to_string()))
+}
+
+/// Strips tags like `<b>`, `<i></i>` from a rendered Telegram HTML body.
+static HTML_TAG_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"<[^>]*>").expect("valid regex"));
+
+/// Cap on title length when wrapping into `<b>…</b>` for the fallback, to stay
+/// under `TELEGRAM_TEXT_MAX_CODEPOINTS` even after HTML-escaping and wrapping.
+const FALLBACK_TITLE_MAX_CODEPOINTS: usize = TELEGRAM_TEXT_MAX_CODEPOINTS - 16;
+
+/// Escape the three characters Telegram's HTML parse_mode treats as markup.
+fn escape_telegram_html(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Return a fallback text + reason when `text` has no visible content, else `None`.
+fn fallback_if_empty(text: &str, alert: &AlertPayload) -> Option<(String, &'static str)> {
+    let reason = if text.is_empty() {
+        "empty_after_render"
+    } else if text.trim().is_empty() {
+        "whitespace_only"
+    } else if HTML_TAG_REGEX.replace_all(text, "").trim().is_empty() {
+        "no_text_content"
+    } else {
+        return None;
+    };
+
+    let fallback = if !alert.message.title.trim().is_empty() {
+        let capped: String = alert
+            .message
+            .title
+            .chars()
+            .take(FALLBACK_TITLE_MAX_CODEPOINTS)
+            .collect();
+        format!("<b>{}</b>", escape_telegram_html(&capped))
+    } else if !alert.rule_name.trim().is_empty() {
+        format!("Alert: {}", escape_telegram_html(&alert.rule_name))
+    } else {
+        "(valerter alert, empty render)".to_string()
+    };
+    Some((fallback, reason))
 }
 
 /// Clamp a parsed retry-after value to the `[RETRY_AFTER_MIN, RETRY_AFTER_MAX]`
@@ -237,7 +289,18 @@ impl TelegramNotifier {
             .as_deref()
             .unwrap_or(DEFAULT_BODY_TEMPLATE);
         let rendered = render_body_template(template, alert)?;
-        Ok(truncate_text(&rendered))
+        let guarded = if let Some((fallback, reason)) = fallback_if_empty(&rendered, alert) {
+            tracing::warn!(
+                rule_name = %alert.rule_name,
+                notifier_name = %self.name,
+                reason = reason,
+                "Telegram body_template rendered empty, applied fallback"
+            );
+            fallback
+        } else {
+            rendered
+        };
+        Ok(truncate_text(&guarded))
     }
 
     /// Send the prepared text to a single chat_id with retry. Returns `Ok` on
@@ -928,4 +991,138 @@ mod tests {
     //    churn in the rest of the module).
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
+
+    // ── fallback_if_empty (#26 empty-render guard) ───────────────────────
+
+    #[test]
+    fn fallback_if_empty_triggers_on_empty() {
+        let alert = sample_alert("", "");
+        let out = fallback_if_empty("", &alert);
+        assert!(out.is_some(), "empty string should trigger fallback");
+        let (_, reason) = out.unwrap();
+        assert_eq!(reason, "empty_after_render");
+    }
+
+    #[test]
+    fn fallback_if_empty_triggers_on_whitespace() {
+        let alert = sample_alert("", "");
+        let out = fallback_if_empty("  \n\t ", &alert);
+        assert!(out.is_some(), "whitespace-only should trigger fallback");
+        let (_, reason) = out.unwrap();
+        assert_eq!(reason, "whitespace_only");
+    }
+
+    #[test]
+    fn fallback_if_empty_triggers_on_html_only() {
+        let alert = sample_alert("", "");
+        let out = fallback_if_empty("<b></b>\n", &alert);
+        assert!(out.is_some(), "html-only should trigger fallback");
+        let (_, reason) = out.unwrap();
+        assert_eq!(reason, "no_text_content");
+    }
+
+    #[test]
+    fn fallback_if_empty_uses_title_when_available() {
+        let alert = sample_alert("Disk full", "");
+        let (text, _) = fallback_if_empty("<b></b>\n", &alert).unwrap();
+        assert_eq!(text, "<b>Disk full</b>");
+    }
+
+    #[test]
+    fn fallback_if_empty_uses_rule_name_as_fallback() {
+        // title is empty → fallback leans on rule_name.
+        let mut alert = sample_alert("", "");
+        alert.rule_name = "nginx-5xx".to_string();
+        let (text, _) = fallback_if_empty("", &alert).unwrap();
+        assert_eq!(text, "Alert: nginx-5xx");
+    }
+
+    #[test]
+    fn fallback_if_empty_uses_literal_when_all_empty() {
+        let mut alert = sample_alert("", "");
+        alert.rule_name = String::new();
+        let (text, _) = fallback_if_empty("", &alert).unwrap();
+        assert_eq!(text, "(valerter alert, empty render)");
+    }
+
+    #[test]
+    fn fallback_escapes_html_specials_in_title() {
+        // Post-review guard: a title containing `<`, `>`, or `&` must not
+        // produce a payload that Telegram's HTML parse_mode would reject.
+        let alert = sample_alert("<script>alert(&amp;)</script>", "");
+        let (text, _) = fallback_if_empty("", &alert).unwrap();
+        assert_eq!(
+            text,
+            "<b>&lt;script&gt;alert(&amp;amp;)&lt;/script&gt;</b>"
+        );
+    }
+
+    #[test]
+    fn fallback_escapes_html_specials_in_rule_name() {
+        let mut alert = sample_alert("", "");
+        alert.rule_name = "a<b & c".to_string();
+        let (text, _) = fallback_if_empty("", &alert).unwrap();
+        assert_eq!(text, "Alert: a&lt;b &amp; c");
+    }
+
+    #[test]
+    fn fallback_caps_long_title_to_stay_under_telegram_limit() {
+        // A pathological 10k-codepoint title must not overflow the
+        // Telegram `text` limit once wrapped in `<b>…</b>`.
+        let long_title: String = "x".repeat(10_000);
+        let alert = sample_alert(&long_title, "");
+        let (text, _) = fallback_if_empty("", &alert).unwrap();
+        assert!(text.chars().count() <= TELEGRAM_TEXT_MAX_CODEPOINTS);
+        assert!(text.starts_with("<b>"));
+        assert!(text.ends_with("</b>"));
+    }
+
+    #[test]
+    fn fallback_if_empty_returns_none_for_non_empty() {
+        let alert = sample_alert("", "");
+        assert!(fallback_if_empty("Hello world", &alert).is_none());
+    }
+
+    #[test]
+    fn fallback_if_empty_returns_none_for_html_with_text() {
+        let alert = sample_alert("", "");
+        assert!(fallback_if_empty("<b>ok</b>", &alert).is_none());
+    }
+
+    // ── prepare_text empty-guard integration ─────────────────────────────
+
+    #[test]
+    fn prepare_text_substitutes_on_empty_render() {
+        // A body_template that renders to literally empty (no vars in context).
+        let client = reqwest::Client::new();
+        let mut cfg = config_with(vec!["-100".to_string()]);
+        cfg.body_template = Some("".to_string());
+        let notifier = TelegramNotifier::from_config("tg", &cfg, client).unwrap();
+        let alert = sample_alert("Disk full", "");
+        let (text, _) = notifier.prepare_text(&alert).unwrap();
+        assert!(!text.trim().is_empty(), "fallback text must not be empty");
+        assert_eq!(text, "<b>Disk full</b>");
+    }
+
+    #[test]
+    fn prepare_text_substitutes_on_html_only_render() {
+        // Reproduces issue #26: default template + empty title/body → "<b></b>\n".
+        let client = reqwest::Client::new();
+        let cfg = config_with(vec!["-100".to_string()]);
+        let notifier = TelegramNotifier::from_config("tg", &cfg, client).unwrap();
+        let mut alert = sample_alert("", "");
+        alert.rule_name = "nginx-5xx".to_string();
+        let (text, _) = notifier.prepare_text(&alert).unwrap();
+        assert_eq!(text, "Alert: nginx-5xx");
+    }
+
+    #[test]
+    fn prepare_text_preserves_non_empty_render() {
+        let client = reqwest::Client::new();
+        let cfg = config_with(vec!["-100".to_string()]);
+        let notifier = TelegramNotifier::from_config("tg", &cfg, client).unwrap();
+        let alert = sample_alert("hello", "world");
+        let (text, _) = notifier.prepare_text(&alert).unwrap();
+        assert_eq!(text, "<b>hello</b>\nworld");
+    }
 }

--- a/src/notify/tests.rs
+++ b/src/notify/tests.rs
@@ -23,7 +23,7 @@ fn make_payload(rule_name: &str) -> AlertPayload {
         message: RenderedMessage {
             title: format!("Alert from {}", rule_name),
             body: "Test body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#ff0000".to_string()),
         },
         rule_name: rule_name.to_string(),
@@ -38,7 +38,7 @@ fn make_payload_with_destinations(rule_name: &str, destinations: Vec<String>) ->
         message: RenderedMessage {
             title: format!("Alert from {}", rule_name),
             body: "Test body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#ff0000".to_string()),
         },
         rule_name: rule_name.to_string(),
@@ -636,7 +636,7 @@ fn alert_payload_clone_works() {
         message: RenderedMessage {
             title: "Test".to_string(),
             body: "Body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#ff0000".to_string()),
         },
         rule_name: "my_rule".to_string(),

--- a/src/notify/webhook.rs
+++ b/src/notify/webhook.rs
@@ -383,7 +383,7 @@ mod tests {
             message: RenderedMessage {
                 title: "Test Alert".to_string(),
                 body: "Something happened".to_string(),
-                body_html: None,
+                email_body_html: None,
                 accent_color: Some("#ff0000".to_string()),
             },
             rule_name: rule_name.to_string(),
@@ -653,7 +653,7 @@ mod tests {
             message: RenderedMessage {
                 title: "Simple".to_string(),
                 body: "Body".to_string(),
-                body_html: None,
+                email_body_html: None,
                 accent_color: None,
             },
             rule_name: "simple_rule".to_string(),
@@ -793,7 +793,7 @@ mod tests {
             message: RenderedMessage {
                 title: "Test".to_string(),
                 body: "Body".to_string(),
-                body_html: None,
+                email_body_html: None,
                 accent_color: Some("#ff0000".to_string()),
             },
             rule_name: "test_rule".to_string(),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -256,9 +256,167 @@ impl RuleParser {
     }
 }
 
+/// Expand flat dotted keys (e.g. `"a.b.c": "x"`) into nested objects, additively.
+///
+/// VictoriaLogs emits fields like `{"nginx.http.request_id": "x"}` as literal flat
+/// keys. minijinja interprets `a.b.c` as nested attribute access, so users writing
+/// `{{ nginx.http.request_id }}` need a nested view of the data.
+///
+/// Behavior:
+/// - Original flat key is preserved (compat with existing `event['a.b']` workarounds).
+/// - Nested objects are added; deep-merged with any pre-existing nested structure.
+/// - On collision (top-level scalar already exists for the first segment), the
+///   scalar wins, the dotted key is left untouched, and a `warn!` is emitted.
+/// - Non-objects pass through unchanged.
+pub(crate) fn unflatten_dotted_keys(value: &Value) -> Value {
+    let Some(map) = value.as_object() else {
+        return value.clone();
+    };
+
+    let mut out: Map<String, Value> = map.clone();
+
+    for (key, val) in map {
+        if !key.contains('.') {
+            continue;
+        }
+        let segments: Vec<&str> = key.split('.').collect();
+        let head = segments[0];
+
+        match out.get(head) {
+            Some(existing) if !existing.is_object() => {
+                tracing::warn!(
+                    conflicting_key = %key,
+                    head_segment = %head,
+                    "skipping dotted-key expansion: top-level scalar already exists"
+                );
+                continue;
+            }
+            _ => {}
+        }
+
+        insert_nested(&mut out, &segments, val.clone());
+    }
+
+    Value::Object(out)
+}
+
+fn insert_nested(out: &mut Map<String, Value>, segments: &[&str], leaf: Value) {
+    let head = segments[0];
+    if segments.len() == 1 {
+        out.insert(head.to_string(), leaf);
+        return;
+    }
+
+    let entry = out
+        .entry(head.to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+
+    if !entry.is_object() {
+        tracing::warn!(
+            head_segment = %head,
+            "skipping nested merge: intermediate scalar collides with nested path"
+        );
+        return;
+    }
+
+    let nested = entry.as_object_mut().expect("checked is_object above");
+    insert_nested(nested, &segments[1..], leaf);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ============================================================
+    // unflatten_dotted_keys tests (issue #25)
+    // ============================================================
+
+    #[test]
+    fn unflatten_basic_single_dotted_key() {
+        let input = serde_json::json!({"nginx.http.request_id": "x"});
+        let out = unflatten_dotted_keys(&input);
+        let obj = out.as_object().unwrap();
+        // Original flat key preserved (additive)
+        assert_eq!(obj.get("nginx.http.request_id").unwrap(), "x");
+        // Nested structure added
+        assert_eq!(
+            obj.get("nginx")
+                .unwrap()
+                .get("http")
+                .unwrap()
+                .get("request_id")
+                .unwrap(),
+            "x"
+        );
+    }
+
+    #[test]
+    fn unflatten_depth_one() {
+        let input = serde_json::json!({"a.b": 1});
+        let out = unflatten_dotted_keys(&input);
+        let obj = out.as_object().unwrap();
+        assert_eq!(obj.get("a.b").unwrap(), 1);
+        assert_eq!(obj.get("a").unwrap().get("b").unwrap(), 1);
+    }
+
+    #[test]
+    fn unflatten_no_dots_unchanged() {
+        let input = serde_json::json!({"simple": 1, "_msg": "x"});
+        let out = unflatten_dotted_keys(&input);
+        let obj = out.as_object().unwrap();
+        assert_eq!(obj.len(), 2);
+        assert_eq!(obj.get("simple").unwrap(), 1);
+        assert_eq!(obj.get("_msg").unwrap(), "x");
+    }
+
+    #[test]
+    fn unflatten_deep_merges_with_existing_nested() {
+        let input = serde_json::json!({"a": {"c": 1}, "a.b": 2});
+        let out = unflatten_dotted_keys(&input);
+        let obj = out.as_object().unwrap();
+        // Flat key preserved
+        assert_eq!(obj.get("a.b").unwrap(), 2);
+        let a = obj.get("a").unwrap();
+        // Existing nested key preserved
+        assert_eq!(a.get("c").unwrap(), 1);
+        // Dotted key merged in
+        assert_eq!(a.get("b").unwrap(), 2);
+    }
+
+    #[test]
+    fn unflatten_scalar_collision_skips_expansion() {
+        let input = serde_json::json!({"a": "scalar", "a.b": 1});
+        let out = unflatten_dotted_keys(&input);
+        let obj = out.as_object().unwrap();
+        // Scalar wins
+        assert_eq!(obj.get("a").unwrap(), "scalar");
+        // Flat key preserved
+        assert_eq!(obj.get("a.b").unwrap(), 1);
+        // No nested expansion
+        assert_eq!(obj.len(), 2);
+    }
+
+    #[test]
+    fn unflatten_multiple_dotted_keys_share_root() {
+        let input = serde_json::json!({
+            "host": "h1",
+            "nginx.http.request_id": "abc",
+            "nginx.http.method": "GET"
+        });
+        let out = unflatten_dotted_keys(&input);
+        let obj = out.as_object().unwrap();
+        let nginx_http = obj.get("nginx").unwrap().get("http").unwrap();
+        assert_eq!(nginx_http.get("request_id").unwrap(), "abc");
+        assert_eq!(nginx_http.get("method").unwrap(), "GET");
+        assert_eq!(obj.get("host").unwrap(), "h1");
+    }
+
+    #[test]
+    fn unflatten_non_object_passes_through() {
+        let input = serde_json::json!("just a string");
+        let out = unflatten_dotted_keys(&input);
+        assert_eq!(out, input);
+    }
 
     // ============================================================
     // Task 1: VictoriaLogs envelope parsing tests

--- a/src/template.rs
+++ b/src/template.rs
@@ -633,7 +633,11 @@ mod tests {
     // Task 9: Tests email_body_html rendering with HTML auto-escape
     // ===================================================================
 
-    fn make_template_with_email_body_html(title: &str, body: &str, email_body_html: &str) -> CompiledTemplate {
+    fn make_template_with_email_body_html(
+        title: &str,
+        body: &str,
+        email_body_html: &str,
+    ) -> CompiledTemplate {
         CompiledTemplate {
             title: title.to_string(),
             body: body.to_string(),

--- a/src/template.rs
+++ b/src/template.rs
@@ -41,7 +41,7 @@ pub struct RenderedMessage {
     /// Body text of the message (attachment text for Mattermost).
     pub body: String,
     /// Optional HTML body for email notifications (rendered with HTML auto-escape).
-    pub body_html: Option<String>,
+    pub email_body_html: Option<String>,
     /// Optional accent color for visual indicators (hex format: #rrggbb).
     /// Used for email colored dot and Mattermost sidebar color.
     pub accent_color: Option<String>,
@@ -59,7 +59,7 @@ pub struct RenderedMessage {
 pub struct TemplateEngine {
     /// Pre-created Jinja environment (created once, reused for performance).
     env: Environment<'static>,
-    /// Pre-created Jinja environment with HTML auto-escape (for body_html rendering).
+    /// Pre-created Jinja environment with HTML auto-escape (for email_body_html rendering).
     html_env: Environment<'static>,
     /// Compiled templates indexed by name.
     templates: HashMap<String, CompiledTemplate>,
@@ -87,7 +87,7 @@ impl TemplateEngine {
         // This returns empty string instead of erroring on undefined variables
         env.set_undefined_behavior(UndefinedBehavior::Lenient);
 
-        // Pre-create HTML environment for body_html rendering (performance optimization)
+        // Pre-create HTML environment for email_body_html rendering (performance optimization)
         let mut html_env = Environment::new();
         html_env.set_undefined_behavior(UndefinedBehavior::Lenient);
         html_env.set_auto_escape_callback(|_| minijinja::AutoEscape::Html);
@@ -137,9 +137,9 @@ impl TemplateEngine {
         let title = self.render_string(&template.title, fields)?;
         let body = self.render_string(&template.body, fields)?;
 
-        // Render body_html with HTML auto-escape if present
-        let body_html = if let Some(body_html_template) = &template.body_html {
-            Some(self.render_string_html_escaped(body_html_template, fields)?)
+        // Render email_body_html with HTML auto-escape if present
+        let email_body_html = if let Some(email_body_html_template) = &template.email_body_html {
+            Some(self.render_string_html_escaped(email_body_html_template, fields)?)
         } else {
             None
         };
@@ -149,13 +149,13 @@ impl TemplateEngine {
         tracing::trace!(
             title_len = title.len(),
             body_len = body.len(),
-            has_body_html = body_html.is_some(),
+            has_email_body_html = email_body_html.is_some(),
             "Template rendered successfully"
         );
         Ok(RenderedMessage {
             title,
             body,
-            body_html,
+            email_body_html,
             accent_color: template.accent_color.clone(),
         })
     }
@@ -171,7 +171,7 @@ impl TemplateEngine {
     }
 
     /// Render a single template string with HTML auto-escape for security.
-    /// Used for body_html to prevent XSS from log data injected into emails.
+    /// Used for email_body_html to prevent XSS from log data injected into emails.
     fn render_string_html_escaped(
         &self,
         template_str: &str,
@@ -225,7 +225,7 @@ impl TemplateEngine {
                 RenderedMessage {
                     title: format!("[{}] Alert", rule_name),
                     body: format!("Template render failed: {}\n\nCheck logs for details.", e),
-                    body_html: None,
+                    email_body_html: None,
                     accent_color: Some("#ff0000".to_string()), // Red for error
                 }
             }
@@ -251,7 +251,7 @@ mod tests {
         CompiledTemplate {
             title: title.to_string(),
             body: body.to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: None,
         }
     }
@@ -264,7 +264,7 @@ mod tests {
         CompiledTemplate {
             title: title.to_string(),
             body: body.to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: accent_color.map(String::from),
         }
     }
@@ -553,14 +553,14 @@ mod tests {
         let msg1 = RenderedMessage {
             title: "Title".to_string(),
             body: "Body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#000000".to_string()),
         };
 
         let msg2 = RenderedMessage {
             title: "Title".to_string(),
             body: "Body".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#000000".to_string()),
         };
 
@@ -630,24 +630,24 @@ mod tests {
     }
 
     // ===================================================================
-    // Task 9: Tests body_html rendering with HTML auto-escape
+    // Task 9: Tests email_body_html rendering with HTML auto-escape
     // ===================================================================
 
-    fn make_template_with_body_html(title: &str, body: &str, body_html: &str) -> CompiledTemplate {
+    fn make_template_with_email_body_html(title: &str, body: &str, email_body_html: &str) -> CompiledTemplate {
         CompiledTemplate {
             title: title.to_string(),
             body: body.to_string(),
-            body_html: Some(body_html.to_string()),
+            email_body_html: Some(email_body_html.to_string()),
             accent_color: None,
         }
     }
 
     #[test]
-    fn render_body_html_is_populated() {
+    fn render_email_body_html_is_populated() {
         let mut templates = HashMap::new();
         templates.insert(
             "email_alert".to_string(),
-            make_template_with_body_html(
+            make_template_with_email_body_html(
                 "Alert: {{ host }}",
                 "Host {{ host }} down",
                 "<p><strong>Host:</strong> {{ host }}</p>",
@@ -661,20 +661,20 @@ mod tests {
 
         assert_eq!(result.title, "Alert: server-01");
         assert_eq!(result.body, "Host server-01 down");
-        assert!(result.body_html.is_some());
+        assert!(result.email_body_html.is_some());
         assert_eq!(
-            result.body_html.unwrap(),
+            result.email_body_html.unwrap(),
             "<p><strong>Host:</strong> server-01</p>"
         );
     }
 
     #[test]
-    fn render_body_html_escapes_html_in_variables() {
+    fn render_email_body_html_escapes_html_in_variables() {
         // AC3: Variables with HTML should be escaped
         let mut templates = HashMap::new();
         templates.insert(
             "email_alert".to_string(),
-            make_template_with_body_html("Alert", "body", "<p>Hostname: {{ hostname }}</p>"),
+            make_template_with_email_body_html("Alert", "body", "<p>Hostname: {{ hostname }}</p>"),
         );
 
         let engine = TemplateEngine::new(templates);
@@ -682,17 +682,17 @@ mod tests {
 
         let result = engine.render("email_alert", &fields).unwrap();
 
-        let body_html = result.body_html.unwrap();
+        let email_body_html = result.email_body_html.unwrap();
         // HTML should be escaped
         assert!(
-            body_html.contains("&lt;script&gt;"),
+            email_body_html.contains("&lt;script&gt;"),
             "Script tags should be escaped: {}",
-            body_html
+            email_body_html
         );
         assert!(
-            !body_html.contains("<script>"),
+            !email_body_html.contains("<script>"),
             "Raw script tags should NOT be present: {}",
-            body_html
+            email_body_html
         );
     }
 
@@ -725,7 +725,7 @@ mod tests {
         let mut templates = HashMap::new();
         templates.insert(
             "my_template".to_string(),
-            make_template_with_body_html(
+            make_template_with_email_body_html(
                 "{{ title }}",
                 "{{ body }}",
                 "<p>{{ hostname }} - {{ nginx.http.request_id }} - {{ nginx.http.method }}</p>",
@@ -745,18 +745,18 @@ mod tests {
         let result = engine.render("my_template", &fields).unwrap();
         assert_eq!(result.title, "T");
         assert_eq!(result.body, "B");
-        let body_html = result.body_html.unwrap();
+        let email_body_html = result.email_body_html.unwrap();
         assert!(
-            body_html.contains("srv-01")
-                && body_html.contains("req-42")
-                && body_html.contains("GET"),
+            email_body_html.contains("srv-01")
+                && email_body_html.contains("req-42")
+                && email_body_html.contains("GET"),
             "expected all dotted fields rendered, got: {}",
-            body_html
+            email_body_html
         );
     }
 
     #[test]
-    fn render_body_html_none_when_template_has_no_body_html() {
+    fn render_email_body_html_none_when_template_has_no_email_body_html() {
         let mut templates = HashMap::new();
         templates.insert(
             "mattermost_alert".to_string(),
@@ -769,8 +769,8 @@ mod tests {
         let result = engine.render("mattermost_alert", &fields).unwrap();
 
         assert!(
-            result.body_html.is_none(),
-            "body_html should be None when template doesn't have it"
+            result.email_body_html.is_none(),
+            "email_body_html should be None when template doesn't have it"
         );
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -162,8 +162,9 @@ impl TemplateEngine {
 
     /// Render a single template string with fields (no auto-escape).
     fn render_string(&self, template_str: &str, fields: &Value) -> Result<String, TemplateError> {
+        let ctx = crate::parser::unflatten_dotted_keys(fields);
         self.env
-            .render_str(template_str, fields)
+            .render_str(template_str, &ctx)
             .map_err(|e| TemplateError::RenderFailed {
                 message: e.to_string(),
             })
@@ -176,8 +177,9 @@ impl TemplateEngine {
         template_str: &str,
         fields: &Value,
     ) -> Result<String, TemplateError> {
+        let ctx = crate::parser::unflatten_dotted_keys(fields);
         self.html_env
-            .render_str(template_str, fields)
+            .render_str(template_str, &ctx)
             .map_err(|e| TemplateError::RenderFailed {
                 message: e.to_string(),
             })
@@ -690,6 +692,65 @@ mod tests {
         assert!(
             !body_html.contains("<script>"),
             "Raw script tags should NOT be present: {}",
+            body_html
+        );
+    }
+
+    // ===================================================================
+    // Issue #25: dotted flat-key resolution at render time
+    // ===================================================================
+
+    #[test]
+    fn render_resolves_dotted_flat_key_via_unflatten() {
+        let mut templates = HashMap::new();
+        templates.insert(
+            "alert".to_string(),
+            make_template(
+                "{{ nginx.http.request_id }}",
+                "id={{ nginx.http.request_id }}",
+            ),
+        );
+
+        let engine = TemplateEngine::new(templates);
+        let fields = json!({"nginx.http.request_id": "abc"});
+
+        let result = engine.render("alert", &fields).unwrap();
+        assert_eq!(result.title, "abc");
+        assert_eq!(result.body, "id=abc");
+    }
+
+    #[test]
+    fn render_issue_25_full_template_end_to_end() {
+        // Mirrors the user's config in issue #25.
+        let mut templates = HashMap::new();
+        templates.insert(
+            "my_template".to_string(),
+            make_template_with_body_html(
+                "{{ title }}",
+                "{{ body }}",
+                "<p>{{ hostname }} - {{ nginx.http.request_id }} - {{ nginx.http.method }}</p>",
+            ),
+        );
+
+        let engine = TemplateEngine::new(templates);
+        let fields = json!({
+            "title": "T",
+            "body": "B",
+            "hostname": "srv-01",
+            "nginx.http.request_id": "req-42",
+            "nginx.http.method": "GET",
+            "nginx.http.status_code": "400"
+        });
+
+        let result = engine.render("my_template", &fields).unwrap();
+        assert_eq!(result.title, "T");
+        assert_eq!(result.body, "B");
+        let body_html = result.body_html.unwrap();
+        assert!(
+            body_html.contains("srv-01")
+                && body_html.contains("req-42")
+                && body_html.contains("GET"),
+            "expected all dotted fields rendered, got: {}",
             body_html
         );
     }

--- a/tests/fixtures/config_email_missing_email_body_html.yaml
+++ b/tests/fixtures/config_email_missing_email_body_html.yaml
@@ -1,4 +1,4 @@
-# Configuration fixture: email notifier with template missing body_html
+# Configuration fixture: email notifier with template missing email_body_html
 # This should fail validation at startup (AC7)
 
 victorialogs:
@@ -13,7 +13,7 @@ templates:
   alert:
     title: "Alert: {{ _msg }}"
     body: "Message: {{ _msg }}"
-    # body_html is missing - should fail validation when used with email
+    # email_body_html is missing - should fail validation when used with email
     accent_color: "#ff0000"
 
 notifiers:

--- a/tests/integration_notify.rs
+++ b/tests/integration_notify.rs
@@ -23,7 +23,7 @@ fn make_payload_with_destinations(rule_name: &str, destinations: Vec<String>) ->
         message: RenderedMessage {
             title: format!("Alert from {}", rule_name),
             body: "Test body content".to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#ff0000".to_string()),
         },
         rule_name: rule_name.to_string(),

--- a/tests/integration_validate.rs
+++ b/tests/integration_validate.rs
@@ -150,35 +150,35 @@ fn validate_disabled_rule_with_invalid_regex_exits_failure() {
     );
 }
 
-// Test: email destination with template missing body_html fails startup
+// Test: email destination with template missing email_body_html fails startup
 // This validates AC2: fail-fast validation prevents runtime errors
-// Note: This test runs valerter normally (not --validate) because the body_html
+// Note: This test runs valerter normally (not --validate) because the email_body_html
 // validation happens after config compilation when creating the NotifierRegistry.
 #[test]
-fn validate_email_missing_body_html_exits_failure() {
+fn validate_email_missing_email_body_html_exits_failure() {
     ensure_binary_built();
 
     let output = Command::new(valerter_binary())
         .args(["-c"])
-        .arg(fixture_path("config_email_missing_body_html.yaml"))
+        .arg(fixture_path("config_email_missing_email_body_html.yaml"))
         .output()
         .expect("Failed to run valerter");
 
     assert!(
         !output.status.success(),
-        "valerter should exit with non-zero code for email destination without body_html"
+        "valerter should exit with non-zero code for email destination without email_body_html"
     );
 
     let exit_code = output.status.code().unwrap_or(-1);
     assert_eq!(
         exit_code, 1,
-        "Exit code should be 1 for missing body_html validation failure"
+        "Exit code should be 1 for missing email_body_html validation failure"
     );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("body_html"),
-        "Error message should mention body_html requirement: {}",
+        stderr.contains("email_body_html"),
+        "Error message should mention email_body_html requirement: {}",
         stderr
     );
     assert!(

--- a/tests/smtp_integration.rs
+++ b/tests/smtp_integration.rs
@@ -213,7 +213,7 @@ fn make_alert_payload(rule_name: &str, title: &str, body: &str) -> AlertPayload 
         message: RenderedMessage {
             title: title.to_string(),
             body: body.to_string(),
-            body_html: None,
+            email_body_html: None,
             accent_color: Some("#ff0000".to_string()),
         },
         rule_name: rule_name.to_string(),
@@ -377,8 +377,8 @@ async fn test_send_email_multiple_recipients() {
     );
 }
 
-/// Test sending HTML formatted email with body_html (pre-escaped HTML content).
-/// AC #4: Verify body_html content is included in email
+/// Test sending HTML formatted email with email_body_html (pre-escaped HTML content).
+/// AC #4: Verify email_body_html content is included in email
 #[tokio::test]
 #[ignore] // Requires running Mailhog
 async fn test_send_email_html_format() {
@@ -392,13 +392,13 @@ async fn test_send_email_html_format() {
     // Create notifier with HTML format
     let notifier = create_mailhog_notifier("html-test");
 
-    // body_html is used for pre-rendered HTML content (from TemplateEngine)
-    // This simulates what TemplateEngine produces when rendering body_html
+    // email_body_html is used for pre-rendered HTML content (from TemplateEngine)
+    // This simulates what TemplateEngine produces when rendering email_body_html
     let alert = AlertPayload {
         message: RenderedMessage {
             title: "HTML Alert".to_string(),
             body: "Fallback plain text".to_string(),
-            body_html: Some(
+            email_body_html: Some(
                 "<h1>Alert!</h1><p>Something <strong>important</strong> happened.</p>".to_string(),
             ),
             accent_color: Some("#ff0000".to_string()),
@@ -435,20 +435,20 @@ async fn test_send_email_html_format() {
         content_type
     );
 
-    // Verify HTML content from body_html is in the email body
-    // body_html is injected as safe (pre-escaped) into the default template
-    // Check for content that appears in body_html (may be quoted-printable encoded)
+    // Verify HTML content from email_body_html is in the email body
+    // email_body_html is injected as safe (pre-escaped) into the default template
+    // Check for content that appears in email_body_html (may be quoted-printable encoded)
     assert!(
         message.content.body.contains("Alert!"),
-        "Body should contain the alert content from body_html"
+        "Body should contain the alert content from email_body_html"
     );
     assert!(
         message.content.body.contains("important"),
-        "Body should contain content from body_html"
+        "Body should contain content from email_body_html"
     );
 }
 
-/// Test sending email with plain text body (no body_html).
+/// Test sending email with plain text body (no email_body_html).
 /// AC #4: Verify plain text body is included in HTML email template
 #[tokio::test]
 #[ignore] // Requires running Mailhog
@@ -463,7 +463,7 @@ async fn test_send_email_text_format() {
     // Create notifier - all emails are now HTML with the default template
     let notifier = create_mailhog_notifier("text-test");
 
-    // No body_html - the plain text body will be used in the HTML template
+    // No email_body_html - the plain text body will be used in the HTML template
     let alert = make_alert_payload(
         "text_rule",
         "Plain Text Alert",


### PR DESCRIPTION
Promotes `release/1.2.0` to `main` after green validation from the original reporter (@congto, #25 and #26).

## Bundled

- **fix #25**: dotted VictoriaLogs fields (`{{ nginx.http.request_id }}`) now work in templates. Previously `--validate` rejected them with a misleading "undefined value" error.
- **fix #26**: Telegram no longer 400s on empty body renders. Structured `warn!` + fallback text. Example config rewritten to clarify that `body`/`body_html` are output slots, not input variables.
- **refactor!**: renamed `body_html` to `email_body_html` (breaking). Only the email notifier ever read this field; the old name was the root cause of #26. Configs using the old name are rejected at load with a clear error listing `email_body_html` among expected fields.
- **docs**: explicit notes in `docs/notifiers.md` that Telegram, Mattermost, and webhook all read `body` and ignore `email_body_html`.

## Validation

- v1.2.0-rc1 tagged and tested live against real-shape nginx events (flat dotted `nginx.http.*` keys).
- Both fixes confirmed end-to-end: empty-body guard fires as expected, dotted fields render as expected.
- Original reporter @congto confirmed on #25 and #26 that the release works on his infra and asked for the final release.

## Release flow

After this merge, `v1.2.0` gets tagged on the merge commit and the release build produces the final binaries and debs.