### PR TITLE
fix(templates): expose rule_name at layer 1 and in throttle key (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.0] - unreleased
+## [1.2.1] - unreleased
+
+### Fixed
+- **`{{ rule_name }}` available in top-level templates and throttle key** (issue #31). `rule_name` is now injected into the render context of `templates.<name>.title`, `body`, and `email_body_html`, and also into the `throttle.key` template, not just the notifier-level `subject_template` / `body_template`. Configs that referenced `{{ rule_name }}` in a top-level template previously rendered an empty string; they now render the rule name. If an event field happens to be literally named `rule_name`, the synthetic rule name wins, matching the collision policy of the existing notifier-level contexts.
+- **Dotted event fields resolve in `throttle.key`**. The unflatten step introduced in v1.2.0 for template rendering (issue #25) now also applies to the throttle key template, so `throttle.key: "{{ nginx.http.status_code }}-{{ hostname }}"` works consistently with `title` / `body`.
+
+## [1.2.0] - 2026-04-15
 
 ### Breaking changes
 - **Template field `body_html` renamed to `email_body_html`** to reflect that

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -106,8 +106,15 @@ defaults:
 #                                              streams configured server-side)
 #      <any parser-extracted field>           JSON field or named regex group
 #      rule_name                              name of the triggered rule
+#                                             (available in `title`, `body`,
+#                                              `email_body_html`, `throttle.key`,
+#                                              and in notifier-level
+#                                              `subject_template` /
+#                                              `body_template`)
 #      log_timestamp                          event timestamp (ISO8601)
+#                                             (notifier-level templates only)
 #      log_timestamp_formatted                human timestamp (defaults.timestamp_timezone)
+#                                             (notifier-level templates only)
 #
 # 2. Template OUTPUT KEYS that you define below (left-hand side). These are
 #    the slots valerter fills and hands off to notifiers:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,10 +206,17 @@ Variables come from the parser output plus built-in fields:
 | `log_timestamp_formatted` | Human-readable timestamp (respects `timestamp_timezone` setting) |
 | Custom fields | Extracted by regex/JSON parser |
 
+**Note:** `rule_name` is available in all template contexts: the top-level
+template fields (`title`, `body`, `email_body_html`), the `throttle.key`, and
+the notifier-level templates (`subject_template`, `body_template`). If an
+event field happens to be named `rule_name`, the synthetic rule name wins.
+
 **Note:** `log_timestamp` and `log_timestamp_formatted` are available in:
 - Email subject and body templates
 - Webhook `body_template`
 - Mattermost footer (automatically includes `log_timestamp_formatted`)
+
+These timestamps are computed **after** the top-level template renders, so they are only accessible in notifier-level templates. If you need a timestamp at the top-level, reference `{{ _time }}` (raw VictoriaLogs field) directly.
 
 ### email_body_html Requirement
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -19,7 +19,7 @@
 //! let engine = TemplateEngine::new(templates);
 //! let fields = json!({"host": "server-01", "severity": "critical"});
 //!
-//! match engine.render("alert_template", &fields) {
+//! match engine.render("alert_template", &fields, "my_rule") {
 //!     Ok(msg) => println!("Title: {}", msg.title),
 //!     Err(e) => eprintln!("Render failed: {}", e),
 //! }
@@ -105,6 +105,10 @@ impl TemplateEngine {
     ///
     /// * `template_name` - Name of the template to render.
     /// * `fields` - Extracted log fields as JSON value.
+    /// * `rule_name` - Name of the rule that triggered this render. Injected
+    ///   into the render context as `rule_name` so templates can reference
+    ///   `{{ rule_name }}` (issue #31). Overrides any event field with the
+    ///   same name.
     ///
     /// # Returns
     ///
@@ -116,12 +120,13 @@ impl TemplateEngine {
     ///
     /// ```ignore
     /// let fields = json!({"host": "server-01", "message": "Alert!"});
-    /// let msg = engine.render("alert", &fields)?;
+    /// let msg = engine.render("alert", &fields, "my_rule")?;
     /// ```
     pub fn render(
         &self,
         template_name: &str,
         fields: &Value,
+        rule_name: &str,
     ) -> Result<RenderedMessage, TemplateError> {
         tracing::trace!(template_name = %template_name, "Starting template render");
 
@@ -133,13 +138,15 @@ impl TemplateEngine {
                     name: template_name.to_string(),
                 })?;
 
-        // Render each field
-        let title = self.render_string(&template.title, fields)?;
-        let body = self.render_string(&template.body, fields)?;
+        // Render each field. rule_name is injected in the render helpers so
+        // it is available at layer 1 (title, body, email_body_html), matching
+        // the existing layer 2 notifier-level contexts (issue #31).
+        let title = self.render_string(&template.title, fields, rule_name)?;
+        let body = self.render_string(&template.body, fields, rule_name)?;
 
         // Render email_body_html with HTML auto-escape if present
         let email_body_html = if let Some(email_body_html_template) = &template.email_body_html {
-            Some(self.render_string_html_escaped(email_body_html_template, fields)?)
+            Some(self.render_string_html_escaped(email_body_html_template, fields, rule_name)?)
         } else {
             None
         };
@@ -161,8 +168,14 @@ impl TemplateEngine {
     }
 
     /// Render a single template string with fields (no auto-escape).
-    fn render_string(&self, template_str: &str, fields: &Value) -> Result<String, TemplateError> {
-        let ctx = crate::parser::unflatten_dotted_keys(fields);
+    fn render_string(
+        &self,
+        template_str: &str,
+        fields: &Value,
+        rule_name: &str,
+    ) -> Result<String, TemplateError> {
+        let mut ctx = crate::parser::unflatten_dotted_keys(fields);
+        inject_rule_name(&mut ctx, rule_name);
         self.env
             .render_str(template_str, &ctx)
             .map_err(|e| TemplateError::RenderFailed {
@@ -176,8 +189,10 @@ impl TemplateEngine {
         &self,
         template_str: &str,
         fields: &Value,
+        rule_name: &str,
     ) -> Result<String, TemplateError> {
-        let ctx = crate::parser::unflatten_dotted_keys(fields);
+        let mut ctx = crate::parser::unflatten_dotted_keys(fields);
+        inject_rule_name(&mut ctx, rule_name);
         self.html_env
             .render_str(template_str, &ctx)
             .map_err(|e| TemplateError::RenderFailed {
@@ -206,7 +221,7 @@ impl TemplateEngine {
         fields: &Value,
         rule_name: &str,
     ) -> RenderedMessage {
-        match self.render(template_name, fields) {
+        match self.render(template_name, fields, rule_name) {
             Ok(msg) => {
                 tracing::trace!(rule_name = %rule_name, "Template render successful");
                 msg
@@ -230,6 +245,21 @@ impl TemplateEngine {
                 }
             }
         }
+    }
+}
+
+/// Inject the synthetic `rule_name` key into a render context (issue #31).
+///
+/// The synthetic value wins over any event field literally named `rule_name`
+/// so operators can rely on `{{ rule_name }}` consistently across layer 1
+/// and layer 2 templates. If `ctx` is not a JSON object (should not happen
+/// in practice — VL events are always objects), injection is skipped.
+fn inject_rule_name(ctx: &mut Value, rule_name: &str) {
+    if let Some(obj) = ctx.as_object_mut() {
+        obj.insert(
+            "rule_name".to_string(),
+            Value::String(rule_name.to_string()),
+        );
     }
 }
 
@@ -290,7 +320,7 @@ mod tests {
             "message": "CPU usage high"
         });
 
-        let result = engine.render("alert", &fields).unwrap();
+        let result = engine.render("alert", &fields, "test_rule").unwrap();
 
         assert_eq!(result.title, "Alert: server-01");
         assert_eq!(result.body, "Host server-01 reported: CPU usage high");
@@ -315,12 +345,12 @@ mod tests {
 
         // Test critical severity
         let fields_critical = json!({"severity": "critical"});
-        let result = engine.render("alert", &fields_critical).unwrap();
+        let result = engine.render("alert", &fields_critical, "test_rule").unwrap();
         assert_eq!(result.title, "🚨 CRITICAL");
 
         // Test non-critical severity
         let fields_warning = json!({"severity": "warning"});
-        let result = engine.render("alert", &fields_warning).unwrap();
+        let result = engine.render("alert", &fields_warning, "test_rule").unwrap();
         assert_eq!(result.title, "⚠️ Warning");
     }
 
@@ -350,7 +380,7 @@ mod tests {
             }
         });
 
-        let result = engine.render("alert", &fields).unwrap();
+        let result = engine.render("alert", &fields, "test_rule").unwrap();
 
         assert_eq!(result.title, "Server: prod-server-01");
         assert_eq!(result.body, "Region: us-east-1, Status: alert");
@@ -372,7 +402,7 @@ mod tests {
         let fields = json!({"host": "server-01"});
 
         // Should NOT return an error, missing field renders as empty string
-        let result = engine.render("alert", &fields).unwrap();
+        let result = engine.render("alert", &fields, "test_rule").unwrap();
 
         assert_eq!(result.title, "Host: server-01");
         assert_eq!(result.body, "Missing: "); // Empty string for missing field
@@ -396,7 +426,7 @@ mod tests {
             "body": "Something went wrong"
         });
 
-        let result = engine.render("full_alert", &fields).unwrap();
+        let result = engine.render("full_alert", &fields, "test_rule").unwrap();
 
         assert_eq!(result.title, "Critical Alert");
         assert_eq!(result.body, "Something went wrong");
@@ -413,7 +443,7 @@ mod tests {
         let engine = TemplateEngine::new(templates);
 
         let fields = json!({"host": "server-01"});
-        let result = engine.render("nonexistent", &fields);
+        let result = engine.render("nonexistent", &fields, "test_rule");
 
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -437,7 +467,7 @@ mod tests {
         let fields = json!({"host": "server-01"});
 
         // render() should return error
-        let result = engine.render("bad_template", &fields);
+        let result = engine.render("bad_template", &fields, "test_rule");
         assert!(result.is_err());
 
         // render_with_fallback() should return fallback message
@@ -466,11 +496,11 @@ mod tests {
 
         // Render for "rule 1"
         let fields1 = json!({"host": "server-01", "message": "Error A"});
-        let result1 = engine.render("shared_template", &fields1).unwrap();
+        let result1 = engine.render("shared_template", &fields1, "rule_1").unwrap();
 
         // Render for "rule 2" with different data
         let fields2 = json!({"host": "server-02", "message": "Error B"});
-        let result2 = engine.render("shared_template", &fields2).unwrap();
+        let result2 = engine.render("shared_template", &fields2, "rule_2").unwrap();
 
         // Both should render correctly with their own data
         assert_eq!(result1.title, "Alert from server-01");
@@ -495,7 +525,7 @@ mod tests {
         let engine = TemplateEngine::new(templates);
         let fields = json!({});
 
-        let result = engine.render("alert", &fields).unwrap();
+        let result = engine.render("alert", &fields, "test_rule").unwrap();
         assert_eq!(result.title, "Static Title");
         assert_eq!(result.body, "Static Body");
     }
@@ -583,7 +613,7 @@ mod tests {
             "items": ["apple", "banana", "cherry"]
         });
 
-        let result = engine.render("list", &fields).unwrap();
+        let result = engine.render("list", &fields, "test_rule").unwrap();
         assert_eq!(result.title, "Items (3)");
         assert!(result.body.contains("- apple"));
         assert!(result.body.contains("- banana"));
@@ -599,7 +629,7 @@ mod tests {
         let engine = TemplateEngine::new(templates);
         let fields = json!({"host": "server-01"});
 
-        let result = engine.render("empty", &fields).unwrap();
+        let result = engine.render("empty", &fields, "test_rule").unwrap();
         assert_eq!(result.title, "");
         assert_eq!(result.body, "");
     }
@@ -625,7 +655,7 @@ mod tests {
             }
         });
 
-        let result = engine.render("deep", &fields).unwrap();
+        let result = engine.render("deep", &fields, "test_rule").unwrap();
         assert_eq!(result.title, "deep_value");
     }
 
@@ -661,7 +691,7 @@ mod tests {
         let engine = TemplateEngine::new(templates);
         let fields = json!({"host": "server-01"});
 
-        let result = engine.render("email_alert", &fields).unwrap();
+        let result = engine.render("email_alert", &fields, "test_rule").unwrap();
 
         assert_eq!(result.title, "Alert: server-01");
         assert_eq!(result.body, "Host server-01 down");
@@ -684,7 +714,7 @@ mod tests {
         let engine = TemplateEngine::new(templates);
         let fields = json!({"hostname": "<script>alert(1)</script>"});
 
-        let result = engine.render("email_alert", &fields).unwrap();
+        let result = engine.render("email_alert", &fields, "test_rule").unwrap();
 
         let email_body_html = result.email_body_html.unwrap();
         // HTML should be escaped
@@ -718,7 +748,7 @@ mod tests {
         let engine = TemplateEngine::new(templates);
         let fields = json!({"nginx.http.request_id": "abc"});
 
-        let result = engine.render("alert", &fields).unwrap();
+        let result = engine.render("alert", &fields, "test_rule").unwrap();
         assert_eq!(result.title, "abc");
         assert_eq!(result.body, "id=abc");
     }
@@ -746,7 +776,7 @@ mod tests {
             "nginx.http.status_code": "400"
         });
 
-        let result = engine.render("my_template", &fields).unwrap();
+        let result = engine.render("my_template", &fields, "test_rule").unwrap();
         assert_eq!(result.title, "T");
         assert_eq!(result.body, "B");
         let email_body_html = result.email_body_html.unwrap();
@@ -757,6 +787,88 @@ mod tests {
             "expected all dotted fields rendered, got: {}",
             email_body_html
         );
+    }
+
+    // ===================================================================
+    // Issue #31: rule_name available in layer 1 templates (title, body,
+    // email_body_html) and in the throttle key, not only in layer 2
+    // notifier-level subject_template / body_template contexts.
+    // ===================================================================
+
+    #[test]
+    fn render_injects_rule_name_in_title() {
+        let mut templates = HashMap::new();
+        templates.insert(
+            "alert".to_string(),
+            make_template("Alert {{ rule_name }}", "body"),
+        );
+
+        let engine = TemplateEngine::new(templates);
+        let fields = json!({"host": "server-01"});
+
+        let result = engine.render("alert", &fields, "VM_OFF").unwrap();
+        assert_eq!(result.title, "Alert VM_OFF");
+    }
+
+    #[test]
+    fn render_injects_rule_name_in_body() {
+        let mut templates = HashMap::new();
+        templates.insert(
+            "alert".to_string(),
+            make_template(
+                "title",
+                "rule={{ rule_name }}\nhost={{ host }}\nrule_again={{ rule_name }}",
+            ),
+        );
+
+        let engine = TemplateEngine::new(templates);
+        let fields = json!({"host": "server-01"});
+
+        let result = engine.render("alert", &fields, "VM_OFF").unwrap();
+        assert_eq!(
+            result.body,
+            "rule=VM_OFF\nhost=server-01\nrule_again=VM_OFF"
+        );
+    }
+
+    #[test]
+    fn render_injects_rule_name_in_email_body_html() {
+        let mut templates = HashMap::new();
+        templates.insert(
+            "email_alert".to_string(),
+            make_template_with_email_body_html(
+                "t",
+                "b",
+                "<p>Rule: {{ rule_name }} on {{ host }}</p>",
+            ),
+        );
+
+        let engine = TemplateEngine::new(templates);
+        let fields = json!({"host": "server-01"});
+
+        let result = engine.render("email_alert", &fields, "VM_OFF").unwrap();
+        assert_eq!(
+            result.email_body_html.unwrap(),
+            "<p>Rule: VM_OFF on server-01</p>"
+        );
+    }
+
+    #[test]
+    fn render_rule_name_synthetic_overrides_event_field() {
+        // Collision policy: synthetic rule_name wins over any event field
+        // literally named "rule_name".
+        let mut templates = HashMap::new();
+        templates.insert(
+            "alert".to_string(),
+            make_template("{{ rule_name }}", "{{ rule_name }}"),
+        );
+
+        let engine = TemplateEngine::new(templates);
+        let fields = json!({"rule_name": "event-value", "host": "server-01"});
+
+        let result = engine.render("alert", &fields, "VM_OFF").unwrap();
+        assert_eq!(result.title, "VM_OFF");
+        assert_eq!(result.body, "VM_OFF");
     }
 
     #[test]
@@ -770,7 +882,7 @@ mod tests {
         let engine = TemplateEngine::new(templates);
         let fields = json!({"host": "server-01"});
 
-        let result = engine.render("mattermost_alert", &fields).unwrap();
+        let result = engine.render("mattermost_alert", &fields, "test_rule").unwrap();
 
         assert!(
             result.email_body_html.is_none(),

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -201,8 +201,13 @@ impl Throttler {
     fn render_key(&self, fields: &Value) -> String {
         match &self.key_template {
             Some(template) => {
+                // Inject synthetic `rule_name` (issue #31) so users can write
+                // `{{ rule_name }}` in throttle.key. Synthetic wins over any
+                // event field with the same name, matching layer 1/2 template
+                // behavior.
+                let enriched_ctx = enrich_with_rule_name(fields, &self.rule_name);
                 // H1 fix: Use pre-created jinja_env instead of creating new one
-                match self.jinja_env.render_str(template, fields) {
+                match self.jinja_env.render_str(template, &enriched_ctx) {
                     Ok(key) => {
                         tracing::trace!(rendered_key = %key, "Throttle key rendered");
                         key
@@ -234,6 +239,25 @@ impl Throttler {
         self.cache.invalidate_all();
         tracing::debug!(rule_name = %self.rule_name, entries_cleared = entry_count, "Throttle cache reset");
     }
+}
+
+/// Unflatten dotted event keys (issue #25) then inject the synthetic
+/// `rule_name` key (issue #31). Matches the layer 1 template rendering path
+/// so users can reference both dotted event fields (`{{ nginx.http.status }}`)
+/// and `{{ rule_name }}` inside a `throttle.key` template consistently.
+///
+/// Returns the original value unchanged if it is not a JSON object (should
+/// not happen in practice, VL events are always objects). The synthetic
+/// value wins over any event field literally named `rule_name`.
+fn enrich_with_rule_name(fields: &Value, rule_name: &str) -> Value {
+    let mut ctx = crate::parser::unflatten_dotted_keys(fields);
+    if let Some(obj) = ctx.as_object_mut() {
+        obj.insert(
+            "rule_name".to_string(),
+            Value::String(rule_name.to_string()),
+        );
+    }
+    ctx
 }
 
 impl std::fmt::Debug for Throttler {
@@ -555,6 +579,54 @@ mod tests {
         assert!(debug.contains("{{ host }}"));
         assert!(debug.contains("max_count"));
         assert!(debug.contains("test_rule"));
+    }
+
+    // ===================================================================
+    // Issue #31: rule_name injected into throttle key render context so
+    // users can write `{{ rule_name }}` in throttle.key and get per-rule
+    // buckets even when sharing a key_template across multiple rules.
+    // ===================================================================
+
+    #[test]
+    fn render_key_includes_rule_name() {
+        let config = make_config(Some("{{ rule_name }}-{{ host }}"), 3, 60);
+        let throttler = Throttler::new(Some(&config), "VM_OFF");
+
+        let fields = json!({"host": "SW-01"});
+        let key = throttler.render_key(&fields);
+
+        assert_eq!(key, "VM_OFF-SW-01");
+    }
+
+    #[test]
+    fn render_key_resolves_dotted_event_fields_via_unflatten() {
+        // Issue #25 + #31: the throttle key must see dotted event keys unflat-
+        // tened the same way template rendering does, so `{{ nginx.http.status }}`
+        // works here too (not just in `title`/`body`).
+        let config = make_config(
+            Some("{{ rule_name }}-{{ nginx.http.status_code }}"),
+            3,
+            60,
+        );
+        let throttler = Throttler::new(Some(&config), "VM_OFF");
+
+        let fields = json!({"nginx.http.status_code": "404"});
+        let key = throttler.render_key(&fields);
+
+        assert_eq!(key, "VM_OFF-404");
+    }
+
+    #[test]
+    fn render_key_rule_name_synthetic_overrides_event_field() {
+        // Collision policy: synthetic rule_name wins over any event field
+        // literally named "rule_name".
+        let config = make_config(Some("{{ rule_name }}"), 3, 60);
+        let throttler = Throttler::new(Some(&config), "VM_OFF");
+
+        let fields = json!({"rule_name": "event-value", "host": "SW-01"});
+        let key = throttler.render_key(&fields);
+
+        assert_eq!(key, "VM_OFF");
     }
 
     #[test]


### PR DESCRIPTION
Fixes [#31](https://github.com/fxthiry/Valerter/issues/31).

## Summary

Users writing `{{ rule_name }}` inside a top-level template (`templates.<name>.title`, `body`, `email_body_html`) or inside a `throttle.key` template previously got an empty string, because `rule_name` was only injected into the notifier-level contexts (email `subject_template`, telegram `body_template`, etc.). @congto hit this while building a Telegram alert with the rule name in the body.

## Changes

- Inject the synthetic `rule_name` String into the rendering context at layer 1 (top-level template fields) and in the throttle key renderer. Synthetic wins over any event field literally named `rule_name`, matching the collision policy of the notifier-level contexts.
- Apply the same `unflatten_dotted_keys` step to the throttle key renderer that v1.2.0 added to templates for [#25](https://github.com/fxthiry/Valerter/issues/25), so dotted event fields like `{{ nginx.http.status_code }}` resolve consistently in `throttle.key` and in `title` / `body`.
- Clarify in `docs/configuration.md` and `config/config.example.yaml` which variables are available at each templating level.

## Non-breaking

Existing configs that referenced `{{ rule_name }}` at layer 1 continue to compile; they now render the rule name instead of an empty string. Configs that did not use these variables render byte-identically to v1.2.0.

## Test plan

- [x] `cargo test --lib` — 451 passed (baseline 444 + 7 new: 4 template + 3 throttle)
- [x] `cargo test` full suite — green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo run --bin valerter -- --validate -c config/config.example.yaml` — exit 0
- [x] Manual live regression: template with `{{ rule_name }}` in title + body, real VictoriaLogs event, both Telegram and email received with the rule name resolved correctly.

## Review hints

Three adversarial reviewers ran on the diff. Two findings patched in the same PR before tagging:
- `CHANGELOG.md` had `[1.2.0] - unreleased` next to `[1.2.1] - unreleased`; dated 1.2.0 to `2026-04-15`.
- `throttle.render_key` skipped the unflatten step introduced in v1.2.0 for templates. Fixed for consistency, test added.

Spec + suggested review order in `_bmad-output/implementation-artifacts/spec-gh-31-rule-name-at-layer-1.md` (local, not in VCS).