### PR TITLE
feat!: multi-source observability and guardrails (v2.0.0 part 2, #34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,13 +40,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Notifier output formats extended with `vl_source`.** The Mattermost footer now reads `valerter | <rule> | <source> | <timestamp>` instead of `valerter | <rule> | <timestamp>`. The default webhook payload exposes `vl_source` as a top-level JSON field. Downstream parsers / dashboards that match exact strings in either output need to update.
 
+- **All per-rule Prometheus metrics now also carry a `vl_source` label.** Affected counters: `valerter_alerts_sent_total`, `valerter_alerts_throttled_total`, `valerter_alerts_passed_total`, `valerter_alerts_failed_total`, `valerter_email_recipient_errors_total`, `valerter_lines_discarded_total`, `valerter_logs_matched_total`, `valerter_notify_errors_total`, `valerter_parse_errors_total`, `valerter_reconnections_total`, `valerter_rule_panics_total`, `valerter_rule_errors_total`. Affected gauge/histogram: `valerter_last_query_timestamp`, `valerter_query_duration_seconds`. Dashboards and alerts that grouped by `rule_name` alone keep working but get an extra `vl_source` dimension; PromQL using `sum by (rule_name) (...)` still rolls up correctly. `valerter_queue_size` stays unlabeled (the queue is shared, not per-source).
+
+- **`valerter_victorialogs_up{rule_name}` removed and replaced by `valerter_vl_source_up{vl_source}`.** The new gauge is per-source (one value per configured source, regardless of how many rules tail it) since reachability is a property of the source, not the rule. Alerts and panels need to migrate from per-rule to per-source semantics. Examples:
+
+  ```promql
+  # v1.x (per-rule):     valerter_victorialogs_up{rule_name="nginx-5xx"} == 0
+  # v2.0.0 (per-source): valerter_vl_source_up{vl_source="prod"} == 0
+
+  # v1.x (any rule down): min(valerter_victorialogs_up) == 0
+  # v2.0.0 (any source):  min(valerter_vl_source_up) == 0
+  ```
+
+  The label key is now `vl_source` (not `rule_name`), and the cardinality drops from `|rules|` to `|sources|`.
+
+- **`defaults.max_streams` cap introduced (default 50).** Total VictoriaLogs streams = sum of `(rule, source)` pairs spawned for enabled rules. Breaching the cap fails the config at load with both the actual count and the cap value. Configurable via `defaults.max_streams: <usize>`. Disabled rules do not contribute. Prevents accidental fan-out from DoSing a backend.
+
 ### Added
 
 - **Multi-source VictoriaLogs support** (issue #34). The engine spawns one task per `(rule, source)` pair with per-source cancellation and reconnect isolation, so a single unhealthy source does not stop alerts on the others.
 - **`{{ vl_source }}` template variable** available everywhere `{{ rule_name }}` is: layer 1 templates (`title`, `body`, `email_body_html`), `throttle.key`, and notifier-level layer 2 contexts (`subject_template`, `body_template`). Always non-empty, owned `String`, equal to the source name currently processing the event. Synthetic value wins over any event field literally named `vl_source` (matches the `rule_name` collision policy).
 - **`AlertPayload.vl_source`** propagated end-to-end so notifiers can render the source name. See Breaking changes above for the related output format updates on Mattermost and webhook destinations.
+- **`valerter_vl_source_up{vl_source}` per-source reachability gauge.** Initialized to 0 for every configured source at startup; engine flips to 1 on tail connect success and back to 0 on permanent failure or stream error. Replaces the v1.x per-rule `valerter_victorialogs_up`.
+- **`±10%` uniform jitter on reconnect backoff** (per `(rule, source)` task). Sources behind a flapping load balancer no longer reconnect in lock-step, breaking the thundering-herd alignment over a few cycles. Hardcoded jitter range; not configurable in this release.
+- **`tests/metrics_snapshot.rs` integration test.** Spins up a 2-source 1-rule engine, scrapes `/metrics`, and asserts the set of metric names + label keys (not values) against an inline expected string. Catches accidental relabel/rename in future PRs.
 
-## [1.2.1] - unreleased
+## [1.2.1] - 2026-04-16
 
 ### Fixed
 - **`{{ rule_name }}` available in top-level templates and throttle key** (issue #31). `rule_name` is now injected into the render context of `templates.<name>.title`, `body`, and `email_body_html`, and also into the `throttle.key` template, not just the notifier-level `subject_template` / `body_template`. Configs that referenced `{{ rule_name }}` in a top-level template previously rendered an empty string; they now render the rule name. If an event field happens to be literally named `rule_name`, the synthetic rule name wins, matching the collision policy of the existing notifier-level contexts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - unreleased
 
+### Security advisory
+
+- **Be cautious when piping raw `_msg` into `email_body_html`.** The example
+  config switched `body: "{{ _msg }}"` in v1.2.0 (#26 fix), and operators may
+  reasonably mirror that in `email_body_html`. The email notifier marks `body`
+  as `safe` (pre-escaped HTML) before injection into the email envelope, so a
+  log line containing raw HTML or `<script>` tags would render unescaped in
+  the recipient's mail client. This is pre-existing behaviour from v1.x, not a
+  regression introduced in v2.0.0, but the surface is wider now that the
+  example actively uses `_msg`. If your VictoriaLogs ingests untrusted
+  content (web request bodies, user-controlled fields), wrap the offending
+  field with `| escape` or render via plain `body` (not `email_body_html`)
+  for email destinations until the email path is hardened in a follow-up.
+
 ### Breaking changes
 
 - **`victorialogs` is now a map of named sources.** A single valerter instance can tail multiple VL backends and route alerts per source. The v1.x single-URL shape (`victorialogs.url: ...` at the top level) is rejected at load with an actionable migration error.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,6 +2350,7 @@ dependencies = [
  "minijinja",
  "moka",
  "portpicker",
+ "rand 0.8.5",
  "regex",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ minijinja = { version = "2.12", features = ["builtins", "json"] }
 # Caching/Throttle
 moka = { version = "0.12", features = ["sync"] }
 
+# Random (jitter on reconnect backoff to break thundering-herd alignment).
+rand = "0.8"
+
 # Observability
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,7 +216,24 @@ defaults:
     count: 5         # Max alerts per window
     window: 60s      # Time window (e.g., 60s, 5m, 1h)
   # timestamp_timezone: "Europe/Paris"  # Optional: timezone for formatted timestamps (default: UTC)
+  # max_streams: 50                     # Optional: hard cap on total VictoriaLogs streams (default: 50)
 ```
+
+### `max_streams` — fan-out guardrail
+
+Multi-source deployments spawn one stream per `(enabled rule, target source)`
+pair. With unscoped fan-out rules and many sources the total scales as
+`rules × sources`, which can DoS a backend by accident. `defaults.max_streams`
+caps that total at load time:
+
+```
+total = sum(if rule.vl_sources is empty then sources.len() else rule.vl_sources.len()
+            for rule in enabled_rules)
+```
+
+Disabled rules do not contribute. Breaching the cap fails `valerter --validate`
+with a message stating both the actual count and the cap so an operator knows
+whether to raise the cap or trim rules. Default: `50`.
 
 ### Timestamp Timezone
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -12,32 +12,40 @@ metrics:
 
 ## Exposed Metrics
 
+> **v2.0.0 — multi-source label.** Every per-rule metric also carries a
+> `vl_source` label naming the VictoriaLogs source that produced the event.
+> The legacy `valerter_victorialogs_up{rule_name}` gauge is **removed** and
+> replaced by `valerter_vl_source_up{vl_source}` (per-source, no `rule_name`).
+> Dashboards that grouped by `rule_name` alone now have an extra dimension
+> available; alerts that matched on `valerter_victorialogs_up` must move to
+> `valerter_vl_source_up`.
+
 ### Counters
 
 | Metric | Labels | Description |
 |--------|--------|-------------|
-| `valerter_alerts_sent_total` | `rule_name`, `notifier_name`, `notifier_type` | Alerts sent successfully |
-| `valerter_alerts_throttled_total` | `rule_name` | Alerts blocked by throttling |
-| `valerter_alerts_passed_total` | `rule_name` | Alerts that passed throttling |
+| `valerter_alerts_sent_total` | `rule_name`, `vl_source`, `notifier_name`, `notifier_type` | Alerts sent successfully |
+| `valerter_alerts_throttled_total` | `rule_name`, `vl_source` | Alerts blocked by throttling |
+| `valerter_alerts_passed_total` | `rule_name`, `vl_source` | Alerts that passed throttling |
 | `valerter_alerts_dropped_total` | - | Alerts dropped (queue full, global counter) |
-| `valerter_alerts_failed_total` | `rule_name`, `notifier_name`, `notifier_type` | Alerts that permanently failed |
-| `valerter_email_recipient_errors_total` | `rule_name`, `notifier_name` | Email delivery failures per recipient |
-| `valerter_lines_discarded_total` | `rule_name`, `reason` | Log lines discarded (e.g., reason=oversized for lines > 1MB) |
-| `valerter_logs_matched_total` | `rule_name` | Logs matched by rule (before throttling) |
+| `valerter_alerts_failed_total` | `rule_name`, `vl_source`, `notifier_name`, `notifier_type` | Alerts that permanently failed |
+| `valerter_email_recipient_errors_total` | `rule_name`, `vl_source`, `notifier_name` | Email delivery failures per recipient |
+| `valerter_lines_discarded_total` | `rule_name`, `vl_source`, `reason` | Log lines discarded (e.g., reason=oversized for lines > 1MB) |
+| `valerter_logs_matched_total` | `rule_name`, `vl_source` | Logs matched by rule (before throttling) |
 | `valerter_notifier_config_errors_total` | `notifier`, `error_type` | Notifier configuration errors (e.g., env var resolution) |
-| `valerter_notify_errors_total` | `rule_name`, `notifier_name`, `notifier_type` | Notification send errors |
-| `valerter_parse_errors_total` | `rule_name`, `error_type` | Parsing errors |
-| `valerter_reconnections_total` | `rule_name` | VictoriaLogs reconnections |
-| `valerter_rule_panics_total` | `rule_name` | Rule task panics (auto-restarted) |
-| `valerter_rule_errors_total` | `rule_name` | Fatal rule errors |
+| `valerter_notify_errors_total` | `rule_name`, `vl_source`, `notifier_name`, `notifier_type` | Notification send errors |
+| `valerter_parse_errors_total` | `rule_name`, `vl_source`, `error_type` | Parsing errors |
+| `valerter_reconnections_total` | `rule_name`, `vl_source` | VictoriaLogs reconnections |
+| `valerter_rule_panics_total` | `rule_name`, `vl_source` | Rule task panics (auto-restarted) |
+| `valerter_rule_errors_total` | `rule_name`, `vl_source` | Fatal rule errors |
 
 ### Gauges
 
 | Metric | Labels | Description |
 |--------|--------|-------------|
-| `valerter_queue_size` | - | Current notification queue size |
-| `valerter_last_query_timestamp` | `rule_name` | Unix timestamp of last successful query |
-| `valerter_victorialogs_up` | `rule_name` | VictoriaLogs connection status (1=connected, 0=disconnected or error) |
+| `valerter_queue_size` | - | Current notification queue size (shared queue, not per-source) |
+| `valerter_last_query_timestamp` | `rule_name`, `vl_source` | Unix timestamp of last successful query chunk |
+| `valerter_vl_source_up` | `vl_source` | Per-source VictoriaLogs reachability (1=connected, 0=disconnected). Replaces v1.x `valerter_victorialogs_up{rule_name}`. |
 | `valerter_uptime_seconds` | - | Time since valerter started |
 | `valerter_build_info` | `version` | Build information (always 1) |
 
@@ -45,7 +53,16 @@ metrics:
 
 | Metric | Labels | Description |
 |--------|--------|-------------|
-| `valerter_query_duration_seconds` | `rule_name` | VictoriaLogs query latency (time to first chunk) |
+| `valerter_query_duration_seconds` | `rule_name`, `vl_source` | VictoriaLogs query latency (time to first chunk) |
+
+### Reconnect Backoff Jitter
+
+Reconnect attempts apply `±10%` uniform jitter per `(rule, source)` task on top
+of the existing exponential backoff (1s base, 60s cap). When `N` sources behind
+a flapping load balancer would otherwise reconnect in lock-step, the jitter
+spreads attempts in a `[0.9·D, 1.1·D]` window so the herd dissolves over a few
+cycles. The jitter is hardcoded (not configurable in v2.0.0) and never drops
+the effective delay below 100ms.
 
 ## Prometheus Scrape Configuration
 
@@ -74,15 +91,15 @@ groups:
           summary: "Valerter rule {{ $labels.rule_name }} not querying"
           description: "No queries received from rule {{ $labels.rule_name }} for over 5 minutes"
 
-      # VictoriaLogs connection lost
-      - alert: ValerterVictoriaLogsDown
-        expr: valerter_victorialogs_up == 0
+      # VictoriaLogs source unreachable (per-source gauge, v2.0.0)
+      - alert: ValerterVlSourceDown
+        expr: valerter_vl_source_up == 0
         for: 2m
         labels:
           severity: critical
         annotations:
-          summary: "Valerter disconnected from VictoriaLogs"
-          description: "Rule {{ $labels.rule_name }} lost connection to VictoriaLogs. Check network and VictoriaLogs health."
+          summary: "Valerter disconnected from VictoriaLogs source {{ $labels.vl_source }}"
+          description: "Source {{ $labels.vl_source }} is unreachable. Check network and VictoriaLogs health."
 
       # Alerts failing to send
       - alert: ValerterAlertsFailing
@@ -128,7 +145,7 @@ groups:
 
 ### Health
 
-- `valerter_victorialogs_up` - VictoriaLogs connection status (1=connected, 0=error)
+- `valerter_vl_source_up` - Per-source VictoriaLogs reachability (1=connected, 0=disconnected)
 - `valerter_uptime_seconds` - Process uptime (detect restarts)
 
 ### Performance

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,9 +21,9 @@ pub use runtime::{
 };
 pub use secret::SecretString;
 pub use types::{
-    BasicAuthConfig, Config, DEFAULT_CONFIG_PATH, DefaultsConfig, JsonParserConfig, MetricsConfig,
-    NotifyConfig, ParserConfig, RuleConfig, TemplateConfig, ThrottleConfig, TlsConfig,
-    VlSourceConfig,
+    BasicAuthConfig, Config, DEFAULT_CONFIG_PATH, DEFAULT_MAX_STREAMS, DefaultsConfig,
+    JsonParserConfig, MetricsConfig, NotifyConfig, ParserConfig, RuleConfig, TemplateConfig,
+    ThrottleConfig, TlsConfig, VlSourceConfig,
 };
 pub use validation::validate_template_render;
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -358,6 +358,7 @@ fn make_runtime_config_with_destinations(destinations: Vec<String>) -> RuntimeCo
                 window: Duration::from_secs(60),
             },
             timestamp_timezone: "UTC".to_string(),
+            max_streams: super::DEFAULT_MAX_STREAMS,
         },
         templates: {
             let mut t = std::collections::HashMap::new();
@@ -472,6 +473,7 @@ fn validate_collects_all_errors() {
                 window: Duration::from_secs(60),
             },
             timestamp_timezone: "UTC".to_string(),
+            max_streams: super::DEFAULT_MAX_STREAMS,
         },
         templates: {
             let mut t = std::collections::HashMap::new();
@@ -558,6 +560,7 @@ fn validate_throttle_key_template() {
                 window: Duration::from_secs(60),
             },
             timestamp_timezone: "UTC".to_string(),
+            max_streams: super::DEFAULT_MAX_STREAMS,
         },
         templates: {
             let mut t = std::collections::HashMap::new();
@@ -629,6 +632,7 @@ fn validate_nonexistent_notify_template_fails() {
                 window: Duration::from_secs(60),
             },
             timestamp_timezone: "UTC".to_string(),
+            max_streams: super::DEFAULT_MAX_STREAMS,
         },
         templates: {
             let mut t = std::collections::HashMap::new();
@@ -1033,6 +1037,7 @@ fn validate_rule_destinations_collects_all_errors() {
                 window: Duration::from_secs(60),
             },
             timestamp_timezone: "UTC".to_string(),
+            max_streams: super::DEFAULT_MAX_STREAMS,
         },
         templates: {
             let mut t = std::collections::HashMap::new();
@@ -2335,4 +2340,182 @@ rules:
         "expected migration YAML snippet in error, got: {}",
         err_str
     );
+}
+
+// ============================================================
+// v2.0.0 part 2: defaults.max_streams cap (multi-source guardrail).
+//
+// Total fan-out is `sum_over_enabled_rules(if vl_sources.is_empty() then
+// sources.len() else vl_sources.len())`. Disabled rules do not contribute.
+// Breach is rejected at load with both numbers in the error.
+// ============================================================
+
+/// YAML helper: build a config with `n_sources` declared sources, `n_rules`
+/// enabled rules each with empty `vl_sources` (full fan-out), and an explicit
+/// `defaults.max_streams: cap`.
+fn config_with_fan_out(n_sources: usize, n_rules: usize, cap: usize) -> String {
+    let mut yaml = String::from("victorialogs:\n");
+    for i in 0..n_sources {
+        yaml.push_str(&format!("  src{}:\n    url: http://h{}:9428\n", i, i));
+    }
+    yaml.push_str(&format!(
+        "defaults:\n  max_streams: {}\n  throttle:\n    count: 5\n    window: 1m\n",
+        cap
+    ));
+    yaml.push_str("templates:\n  t:\n    title: x\n    body: y\n");
+    yaml.push_str(
+        "notifiers:\n  n:\n    type: mattermost\n    webhook_url: https://example.com/hooks/x\n",
+    );
+    yaml.push_str("rules:\n");
+    for i in 0..n_rules {
+        yaml.push_str(&format!(
+            "  - name: r{}\n    query: 't'\n    parser:\n      json:\n        fields: [_msg]\n    notify:\n      template: t\n      destinations: [n]\n",
+            i
+        ));
+    }
+    yaml
+}
+
+#[test]
+fn validate_max_streams_under_cap_passes() {
+    // 3 sources × 4 fan-out rules = 12 streams ≤ 50.
+    let yaml = config_with_fan_out(3, 4, 50);
+    let config: Config = serde_yaml::from_str(&yaml).unwrap();
+    config
+        .validate()
+        .expect("12 streams under cap of 50 should validate");
+}
+
+#[test]
+fn validate_max_streams_at_exact_cap_passes() {
+    // 5 × 10 = 50, exactly the cap — boundary case allowed.
+    let yaml = config_with_fan_out(5, 10, 50);
+    let config: Config = serde_yaml::from_str(&yaml).unwrap();
+    config
+        .validate()
+        .expect("50 streams at cap of 50 should validate");
+}
+
+#[test]
+fn validate_max_streams_breach_fails_with_actual_and_cap() {
+    // 5 sources × 12 fan-out rules = 60 > 50.
+    let yaml = config_with_fan_out(5, 12, 50);
+    let config: Config = serde_yaml::from_str(&yaml).unwrap();
+    let errors = config.validate().expect_err("60 streams > cap should fail");
+    let has_max_streams_error = errors.iter().any(|e| match e {
+        crate::error::ConfigError::ValidationError(msg) => {
+            msg.contains("max_streams") && msg.contains("60") && msg.contains("50")
+        }
+        _ => false,
+    });
+    assert!(
+        has_max_streams_error,
+        "expected max_streams error mentioning actual=60 and cap=50, got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn validate_max_streams_default_value_is_fifty() {
+    // Omit `defaults.max_streams` entirely → DEFAULT_MAX_STREAMS (50). 51
+    // streams must fail; the default is what the cap reads as.
+    let mut yaml = String::from("victorialogs:\n");
+    for i in 0..51 {
+        yaml.push_str(&format!("  src{}:\n    url: http://h{}:9428\n", i, i));
+    }
+    yaml.push_str("defaults:\n  throttle:\n    count: 5\n    window: 1m\n");
+    yaml.push_str("templates:\n  t:\n    title: x\n    body: y\n");
+    yaml.push_str(
+        "notifiers:\n  n:\n    type: mattermost\n    webhook_url: https://example.com/hooks/x\n",
+    );
+    yaml.push_str("rules:\n  - name: r0\n    query: 't'\n    parser:\n      json:\n        fields: [_msg]\n    notify:\n      template: t\n      destinations: [n]\n");
+    let config: Config = serde_yaml::from_str(&yaml).unwrap();
+    let errors = config
+        .validate()
+        .expect_err("51 streams under default cap of 50 should fail");
+    assert!(
+        errors.iter().any(|e| matches!(
+            e,
+            crate::error::ConfigError::ValidationError(m) if m.contains("max_streams")
+        )),
+        "expected max_streams error, got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn validate_max_streams_disabled_rules_do_not_contribute() {
+    // 5 sources × (1 enabled fan-out rule + 100 disabled fan-out rules) =
+    // 5 enabled streams. Even though raw `vl_sources.len()` would sum to
+    // hundreds if we counted disabled rules, the cap is on enabled only.
+    let mut yaml = String::from("victorialogs:\n");
+    for i in 0..5 {
+        yaml.push_str(&format!("  src{}:\n    url: http://h{}:9428\n", i, i));
+    }
+    yaml.push_str("defaults:\n  max_streams: 5\n  throttle:\n    count: 5\n    window: 1m\n");
+    yaml.push_str("templates:\n  t:\n    title: x\n    body: y\n");
+    yaml.push_str(
+        "notifiers:\n  n:\n    type: mattermost\n    webhook_url: https://example.com/hooks/x\n",
+    );
+    yaml.push_str("rules:\n");
+    yaml.push_str("  - name: enabled_rule\n    query: 't'\n    parser:\n      json:\n        fields: [_msg]\n    notify:\n      template: t\n      destinations: [n]\n");
+    for i in 0..100 {
+        yaml.push_str(&format!(
+            "  - name: disabled{}\n    enabled: false\n    query: 't'\n    parser:\n      json:\n        fields: [_msg]\n    notify:\n      template: t\n      destinations: [n]\n",
+            i
+        ));
+    }
+    let config: Config = serde_yaml::from_str(&yaml).unwrap();
+    config
+        .validate()
+        .expect("disabled rules should not contribute to fan-out total");
+}
+
+#[test]
+fn validate_max_streams_pinned_rule_counts_only_listed_sources() {
+    // 5 sources, 2 pinned rules each `vl_sources: [src0]`, 3 fan-out rules.
+    // total = 2*1 + 3*5 = 17, well under default cap.
+    let yaml = r#"
+victorialogs:
+  src0: { url: http://h0:9428 }
+  src1: { url: http://h1:9428 }
+  src2: { url: http://h2:9428 }
+  src3: { url: http://h3:9428 }
+  src4: { url: http://h4:9428 }
+defaults:
+  throttle:
+    count: 5
+    window: 1m
+templates:
+  t: { title: x, body: y }
+notifiers:
+  n: { type: mattermost, webhook_url: https://example.com/hooks/x }
+rules:
+  - name: pinned1
+    query: 't'
+    parser: { json: { fields: [_msg] } }
+    vl_sources: [src0]
+    notify: { template: t, destinations: [n] }
+  - name: pinned2
+    query: 't'
+    parser: { json: { fields: [_msg] } }
+    vl_sources: [src0]
+    notify: { template: t, destinations: [n] }
+  - name: fan1
+    query: 't'
+    parser: { json: { fields: [_msg] } }
+    notify: { template: t, destinations: [n] }
+  - name: fan2
+    query: 't'
+    parser: { json: { fields: [_msg] } }
+    notify: { template: t, destinations: [n] }
+  - name: fan3
+    query: 't'
+    parser: { json: { fields: [_msg] } }
+    notify: { template: t, destinations: [n] }
+"#;
+    let config: Config = serde_yaml::from_str(yaml).unwrap();
+    config
+        .validate()
+        .expect("17 streams under default cap of 50 should validate");
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -197,6 +197,25 @@ pub struct DefaultsConfig {
     /// Timezone for formatted timestamps (e.g., "UTC", "Europe/Paris").
     #[serde(default = "default_timestamp_timezone")]
     pub timestamp_timezone: String,
+    /// Maximum total number of concurrent VictoriaLogs streams (sum of
+    /// `(rule, source)` task pairs for enabled rules). Hard cap enforced at
+    /// load time to prevent unintentional fan-out from DoSing a backend.
+    ///
+    /// Default: 50. Configurable via `defaults.max_streams: <usize>` in
+    /// `config.yaml`.
+    #[serde(default = "default_max_streams")]
+    pub max_streams: usize,
+}
+
+/// Default upper bound on the total number of concurrent VL streams.
+///
+/// Picked to comfortably accommodate small/mid-size deployments (~10 sources ×
+/// a handful of fan-out rules) while still failing fast on accidentally large
+/// fan-outs. Configurable per-deployment via `defaults.max_streams`.
+pub const DEFAULT_MAX_STREAMS: usize = 50;
+
+fn default_max_streams() -> usize {
+    DEFAULT_MAX_STREAMS
 }
 
 fn default_timestamp_timezone() -> String {
@@ -765,6 +784,40 @@ impl Config {
             errors.push(ConfigError::ValidationError(format!(
                 "defaults.timestamp_timezone '{}' is not a valid timezone",
                 self.defaults.timestamp_timezone
+            )));
+        }
+
+        // Validate `defaults.max_streams` cap against the actual fan-out.
+        // Total stream count = sum, over enabled rules, of:
+        //   - `sources.len()` if `rule.vl_sources` is empty (fan out across all)
+        //   - `rule.vl_sources.len()` otherwise.
+        // Disabled rules do not contribute. Enforced at load (not runtime) so
+        // a misconfigured fan-out fails fast at startup.
+        if self.defaults.max_streams == 0 {
+            errors.push(ConfigError::ValidationError(
+                "defaults.max_streams must be >= 1 (a value of 0 would reject every config). \
+                 Omit the field to use the default (50) or set an explicit positive value."
+                    .to_string(),
+            ));
+        }
+        let source_count = self.victorialogs.len();
+        let total_streams: usize = self
+            .rules
+            .iter()
+            .filter(|r| r.enabled)
+            .map(|r| {
+                if r.vl_sources.is_empty() {
+                    source_count
+                } else {
+                    r.vl_sources.len()
+                }
+            })
+            .sum();
+        if total_streams > self.defaults.max_streams {
+            errors.push(ConfigError::ValidationError(format!(
+                "defaults.max_streams exceeded: {} stream(s) required by enabled rules > cap of {}. \
+                 Either raise `defaults.max_streams` or trim rules / `vl_sources` to reduce fan-out.",
+                total_streams, self.defaults.max_streams
             )));
         }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -281,7 +281,8 @@ impl RuleEngine {
                             );
                             metrics::counter!(
                                 "valerter_rule_errors_total",
-                                "rule_name" => rule_name
+                                "rule_name" => rule_name,
+                                "vl_source" => vl_source,
                             ).increment(1);
                             handle_to_context.remove(&task_id);
                         }
@@ -297,7 +298,8 @@ impl RuleEngine {
 
                                 metrics::counter!(
                                     "valerter_rule_panics_total",
-                                    "rule_name" => rule_name.clone()
+                                    "rule_name" => rule_name.clone(),
+                                    "vl_source" => vl_source.clone(),
                                 ).increment(1);
 
                                 if !cancel.is_cancelled() {
@@ -324,7 +326,12 @@ impl RuleEngine {
                                     error = %join_error,
                                     "Rule task panicked but context not found - CRITICAL"
                                 );
-                                metrics::counter!("valerter_rule_panics_total", "rule_name" => "unknown").increment(1);
+                                metrics::counter!(
+                                    "valerter_rule_panics_total",
+                                    "rule_name" => "unknown",
+                                    "vl_source" => "unknown",
+                                )
+                                .increment(1);
                             }
                         }
                         Err(join_error) => {
@@ -382,7 +389,11 @@ impl ThrottleResetCallback {
 }
 
 impl ReconnectCallback for ThrottleResetCallback {
-    fn on_reconnect(&self, _rule_name: &str) {
+    fn on_reconnect(&self, _rule_name: &str, _vl_source: &str) {
+        // Each (rule, source) task owns its own Throttler instance, so a
+        // reset here is already scoped to the source that just recovered.
+        // The vl_source parameter is accepted for trait conformance and
+        // future use (e.g. selective reset across shared throttle stores).
         self.throttler.reset();
     }
 }
@@ -462,43 +473,48 @@ async fn run_rule(ctx: RuleSpawnContext, cancel: CancellationToken) -> Result<()
         let timestamp_timezone = Arc::new(ctx.timestamp_timezone.clone());
 
         let stream_result = tail_client
-            .stream_with_reconnect(&rule_name, Some(&reconnect_callback), |line| {
-                // Process each log line
-                let queue = queue.clone();
-                let parser = Arc::clone(&parser);
-                let throttler = Arc::clone(&throttler);
-                let template_engine = Arc::clone(&template_engine);
-                let template_name = Arc::clone(&template_name);
-                let rule_name = rule_name.clone();
-                let vl_source = Arc::clone(&vl_source);
-                let destinations = Arc::clone(&destinations);
-                let timestamp_timezone = Arc::clone(&timestamp_timezone);
+            .stream_with_reconnect(
+                &rule_name,
+                vl_source.as_str(),
+                Some(&reconnect_callback),
+                |line| {
+                    // Process each log line
+                    let queue = queue.clone();
+                    let parser = Arc::clone(&parser);
+                    let throttler = Arc::clone(&throttler);
+                    let template_engine = Arc::clone(&template_engine);
+                    let template_name = Arc::clone(&template_name);
+                    let rule_name = rule_name.clone();
+                    let vl_source = Arc::clone(&vl_source);
+                    let destinations = Arc::clone(&destinations);
+                    let timestamp_timezone = Arc::clone(&timestamp_timezone);
 
-                async move {
-                    if let Err(e) = process_log_line(
-                        &line,
-                        &parser,
-                        &throttler,
-                        &template_engine,
-                        &template_name,
-                        &rule_name,
-                        &vl_source,
-                        &destinations,
-                        &queue,
-                        &timestamp_timezone,
-                    )
-                    .await
-                    {
-                        debug!(
-                            rule_name = %rule_name,
-                            vl_source = %vl_source,
-                            error = %e,
-                            "Failed to process log line, continuing"
-                        );
+                    async move {
+                        if let Err(e) = process_log_line(
+                            &line,
+                            &parser,
+                            &throttler,
+                            &template_engine,
+                            &template_name,
+                            &rule_name,
+                            &vl_source,
+                            &destinations,
+                            &queue,
+                            &timestamp_timezone,
+                        )
+                        .await
+                        {
+                            debug!(
+                                rule_name = %rule_name,
+                                vl_source = %vl_source,
+                                error = %e,
+                                "Failed to process log line, continuing"
+                            );
+                        }
+                        Ok(())
                     }
-                    Ok(())
-                }
-            })
+                },
+            )
             .await;
 
         if cancel.is_cancelled() {
@@ -543,13 +559,13 @@ async fn process_log_line(
             f
         }
         Err(e) => {
-            record_parse_error(rule_name, &e);
+            record_parse_error(rule_name, vl_source, &e);
             return Err(ProcessError::Parse);
         }
     };
 
     // Step 1.5: Record successful match (before throttle check)
-    record_log_matched(rule_name);
+    record_log_matched(rule_name, vl_source);
 
     // Step 2: Check throttle (renders key with both rule_name and vl_source)
     match throttler.check(&fields) {
@@ -681,6 +697,7 @@ mod tests {
                     window: Duration::from_secs(60),
                 },
                 timestamp_timezone: "UTC".to_string(),
+                max_streams: crate::config::DEFAULT_MAX_STREAMS,
             },
             templates: {
                 let mut t = HashMap::new();
@@ -1085,7 +1102,7 @@ mod tests {
         assert_eq!(throttler.check(&fields), ThrottleResult::Throttled);
 
         // Reset via callback
-        callback.on_reconnect("test_rule");
+        callback.on_reconnect("test_rule", "vlprod");
 
         // Should pass again after reset
         assert_eq!(throttler.check(&fields), ThrottleResult::Pass);

--- a/src/main.rs
+++ b/src/main.rs
@@ -339,12 +339,38 @@ async fn run(runtime_config: valerter::config::RuntimeConfig) -> Result<()> {
     // Create cancellation token for graceful shutdown
     let cancel = CancellationToken::new();
 
-    // Collect rule and notifier names for metric initialization
-    let rule_names: Vec<&str> = runtime_config
+    // Collect rule-source pairs and source names for metric initialization.
+    //
+    // Multi-source observability (v2.0.0 part 2): every per-rule metric also
+    // carries `vl_source`, so initialization seeds one series per
+    // `(enabled rule, resolved source)` pair. The `vl_source_up` gauge is
+    // per-source only, so we also pass the flat list of declared sources.
+    let source_names: Vec<&str> = runtime_config
+        .victorialogs
+        .keys()
+        .map(String::as_str)
+        .collect();
+    let rule_source_pairs: Vec<(&str, &str)> = runtime_config
         .rules
         .iter()
         .filter(|r| r.enabled)
-        .map(|r| r.name.as_str())
+        .flat_map(|r| {
+            // Same fan-out semantics the engine uses: empty `vl_sources` means
+            // "every configured source", non-empty restricts to the named
+            // subset (intersected with declared sources for safety).
+            if r.vl_sources.is_empty() {
+                source_names
+                    .iter()
+                    .map(move |s| (r.name.as_str(), *s))
+                    .collect::<Vec<_>>()
+            } else {
+                r.vl_sources
+                    .iter()
+                    .filter(|s| runtime_config.victorialogs.contains_key(s.as_str()))
+                    .map(move |s| (r.name.as_str(), s.as_str()))
+                    .collect::<Vec<_>>()
+            }
+        })
         .collect();
     let notifier_names: Vec<&str> = registry.names().collect();
 
@@ -373,7 +399,7 @@ async fn run(runtime_config: valerter::config::RuntimeConfig) -> Result<()> {
         }
 
         // Initialize all known metrics to zero now that recorder is ready
-        valerter::initialize_metrics(&rule_names, &notifier_names);
+        valerter::initialize_metrics(&rule_source_pairs, &source_names, &notifier_names);
 
         Some(handle)
     } else {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -80,8 +80,9 @@ pub fn register_metric_descriptions() {
         "Unix timestamp of last successful VictoriaLogs query chunk received"
     );
     describe_gauge!(
-        "valerter_victorialogs_up",
-        "VictoriaLogs connection status (1=connected, 0=disconnected or error)"
+        "valerter_vl_source_up",
+        "Per-source VictoriaLogs reachability (1=connected, 0=disconnected). \
+         Replaces the v1.x per-rule `valerter_victorialogs_up`."
     );
     describe_gauge!(
         "valerter_uptime_seconds",
@@ -198,9 +199,17 @@ pub fn is_recorder_installed() -> bool {
 ///
 /// # Arguments
 ///
-/// * `rule_names` - List of rule names to initialize per-rule counters
-/// * `notifier_names` - List of notifier names to initialize per-notifier counters
-pub fn initialize_metrics(rule_names: &[&str], notifier_names: &[&str]) {
+/// * `rule_source_pairs` - List of `(rule_name, vl_source)` pairs to initialize
+///   per-(rule, source) counters. Same shape the engine spawns tasks for.
+/// * `source_names` - List of every configured `vl_source` (independent of
+///   which rules tail it). Used to seed the per-source `valerter_vl_source_up`
+///   gauge to 0 at startup.
+/// * `notifier_names` - List of notifier names to initialize per-notifier counters.
+pub fn initialize_metrics(
+    rule_source_pairs: &[(&str, &str)],
+    source_names: &[&str],
+    notifier_names: &[&str],
+) {
     use metrics::{counter, gauge};
 
     // Initialize gauges with their initial values
@@ -208,30 +217,92 @@ pub fn initialize_metrics(rule_names: &[&str], notifier_names: &[&str]) {
     gauge!("valerter_uptime_seconds").set(0.0);
     gauge!("valerter_queue_size").set(0.0);
 
-    // Initialize per-rule gauges
-    for rule_name in rule_names {
-        gauge!("valerter_victorialogs_up", "rule_name" => rule_name.to_string()).set(0.0);
+    // Initialize per-source `vl_source_up` gauge to 0 for every configured
+    // source. The engine flips it to 1 on the first successful tail connect.
+    for source_name in source_names {
+        gauge!("valerter_vl_source_up", "vl_source" => source_name.to_string()).set(0.0);
     }
 
     // Initialize counters without labels (global counters)
-    counter!("valerter_reconnections_total").absolute(0);
-
-    // Initialize global counters (no labels)
     counter!("valerter_alerts_dropped_total").absolute(0);
 
-    // Initialize per-rule counters
-    for rule_name in rule_names {
-        counter!("valerter_logs_matched_total", "rule_name" => rule_name.to_string()).absolute(0);
-        counter!("valerter_alerts_sent_total", "rule_name" => rule_name.to_string()).absolute(0);
-        counter!("valerter_alerts_throttled_total", "rule_name" => rule_name.to_string())
-            .absolute(0);
-        counter!("valerter_alerts_passed_total", "rule_name" => rule_name.to_string()).absolute(0);
-        counter!("valerter_parse_errors_total", "rule_name" => rule_name.to_string()).absolute(0);
-        counter!("valerter_rule_panics_total", "rule_name" => rule_name.to_string()).absolute(0);
-        counter!("valerter_rule_errors_total", "rule_name" => rule_name.to_string()).absolute(0);
+    // Initialize per-(rule, source) counters. Every per-rule metric also
+    // carries `vl_source` (v2.0.0 multi-source observability).
+    for (rule_name, vl_source) in rule_source_pairs {
+        counter!(
+            "valerter_logs_matched_total",
+            "rule_name" => rule_name.to_string(),
+            "vl_source" => vl_source.to_string(),
+        )
+        .absolute(0);
+        counter!(
+            "valerter_alerts_sent_total",
+            "rule_name" => rule_name.to_string(),
+            "vl_source" => vl_source.to_string(),
+        )
+        .absolute(0);
+        counter!(
+            "valerter_alerts_throttled_total",
+            "rule_name" => rule_name.to_string(),
+            "vl_source" => vl_source.to_string(),
+        )
+        .absolute(0);
+        counter!(
+            "valerter_alerts_passed_total",
+            "rule_name" => rule_name.to_string(),
+            "vl_source" => vl_source.to_string(),
+        )
+        .absolute(0);
+        counter!(
+            "valerter_parse_errors_total",
+            "rule_name" => rule_name.to_string(),
+            "vl_source" => vl_source.to_string(),
+        )
+        .absolute(0);
+        counter!(
+            "valerter_rule_panics_total",
+            "rule_name" => rule_name.to_string(),
+            "vl_source" => vl_source.to_string(),
+        )
+        .absolute(0);
+        counter!(
+            "valerter_rule_errors_total",
+            "rule_name" => rule_name.to_string(),
+            "vl_source" => vl_source.to_string(),
+        )
+        .absolute(0);
+        counter!(
+            "valerter_reconnections_total",
+            "rule_name" => rule_name.to_string(),
+            "vl_source" => vl_source.to_string(),
+        )
+        .absolute(0);
+        counter!(
+            "valerter_lines_discarded_total",
+            "rule_name" => rule_name.to_string(),
+            "vl_source" => vl_source.to_string(),
+            "reason" => "oversized",
+        )
+        .absolute(0);
+        // Histograms can't be `absolute(0)` but referencing the handle here
+        // registers the series so it appears in /metrics from startup.
+        let _ = metrics::histogram!(
+            "valerter_query_duration_seconds",
+            "rule_name" => rule_name.to_string(),
+            "vl_source" => vl_source.to_string(),
+        );
+        gauge!(
+            "valerter_last_query_timestamp",
+            "rule_name" => rule_name.to_string(),
+            "vl_source" => vl_source.to_string(),
+        )
+        .set(0.0);
     }
 
-    // Initialize per-notifier counters
+    // Initialize per-notifier counters. The actual emit sites carry
+    // (rule_name, vl_source) labels; this loop pre-registers a per-notifier
+    // sentinel series so dashboards listing notifiers see them at startup.
+    // The two label sets coexist legitimately (different aggregations).
     for notifier_name in notifier_names {
         counter!("valerter_alerts_failed_total", "notifier" => notifier_name.to_string())
             .absolute(0);
@@ -240,7 +311,8 @@ pub fn initialize_metrics(rule_names: &[&str], notifier_names: &[&str]) {
     }
 
     tracing::info!(
-        rule_count = rule_names.len(),
+        rule_source_pair_count = rule_source_pairs.len(),
+        source_count = source_names.len(),
         notifier_count = notifier_names.len(),
         "Metrics initialized to zero"
     );

--- a/src/notify/email.rs
+++ b/src/notify/email.rs
@@ -583,7 +583,8 @@ impl Notifier for EmailNotifier {
                         metrics::counter!(
                             "valerter_email_recipient_errors_total",
                             "rule_name" => alert.rule_name.clone(),
-                            "notifier_name" => self.name.clone()
+                            "vl_source" => alert.vl_source.clone(),
+                            "notifier_name" => self.name.clone(),
                         )
                         .increment(1);
                     }
@@ -604,8 +605,9 @@ impl Notifier for EmailNotifier {
                 metrics::counter!(
                     "valerter_alerts_sent_total",
                     "rule_name" => alert.rule_name.clone(),
+                    "vl_source" => alert.vl_source.clone(),
                     "notifier_name" => self.name.clone(),
-                    "notifier_type" => "email"
+                    "notifier_type" => "email",
                 )
                 .increment(1);
                 Ok(())
@@ -620,16 +622,18 @@ impl Notifier for EmailNotifier {
                 metrics::counter!(
                     "valerter_notify_errors_total",
                     "rule_name" => alert.rule_name.clone(),
+                    "vl_source" => alert.vl_source.clone(),
                     "notifier_name" => self.name.clone(),
-                    "notifier_type" => "email"
+                    "notifier_type" => "email",
                 )
                 .increment(1);
                 // Permanent failure - all recipients failed
                 metrics::counter!(
                     "valerter_alerts_failed_total",
                     "rule_name" => alert.rule_name.clone(),
+                    "vl_source" => alert.vl_source.clone(),
                     "notifier_name" => self.name.clone(),
-                    "notifier_type" => "email"
+                    "notifier_type" => "email",
                 )
                 .increment(1);
                 Err(NotifyError::SendFailed(format!(

--- a/src/notify/mattermost.rs
+++ b/src/notify/mattermost.rs
@@ -202,8 +202,9 @@ impl Notifier for MattermostNotifier {
                         metrics::counter!(
                             "valerter_alerts_sent_total",
                             "rule_name" => alert.rule_name.clone(),
+                            "vl_source" => alert.vl_source.clone(),
                             "notifier_name" => self.name.clone(),
-                            "notifier_type" => "mattermost"
+                            "notifier_type" => "mattermost",
                         )
                         .increment(1);
                         return Ok(());
@@ -218,16 +219,18 @@ impl Notifier for MattermostNotifier {
                         metrics::counter!(
                             "valerter_notify_errors_total",
                             "rule_name" => alert.rule_name.clone(),
+                            "vl_source" => alert.vl_source.clone(),
                             "notifier_name" => self.name.clone(),
-                            "notifier_type" => "mattermost"
+                            "notifier_type" => "mattermost",
                         )
                         .increment(1);
                         // Permanent failure - count as failed alert
                         metrics::counter!(
                             "valerter_alerts_failed_total",
                             "rule_name" => alert.rule_name.clone(),
+                            "vl_source" => alert.vl_source.clone(),
                             "notifier_name" => self.name.clone(),
-                            "notifier_type" => "mattermost"
+                            "notifier_type" => "mattermost",
                         )
                         .increment(1);
                         return Err(NotifyError::SendFailed(format!("client error: {}", status)));
@@ -267,16 +270,18 @@ impl Notifier for MattermostNotifier {
             metrics::counter!(
                 "valerter_notify_errors_total",
                 "rule_name" => alert.rule_name.clone(),
+                "vl_source" => alert.vl_source.clone(),
                 "notifier_name" => self.name.clone(),
-                "notifier_type" => "mattermost"
+                "notifier_type" => "mattermost",
             )
             .increment(1);
             // Permanent failure after retries exhausted
             metrics::counter!(
                 "valerter_alerts_failed_total",
                 "rule_name" => alert.rule_name.clone(),
+                "vl_source" => alert.vl_source.clone(),
                 "notifier_name" => self.name.clone(),
-                "notifier_type" => "mattermost"
+                "notifier_type" => "mattermost",
             )
             .increment(1);
             Err(NotifyError::MaxRetriesExceeded)

--- a/src/notify/queue.rs
+++ b/src/notify/queue.rs
@@ -190,7 +190,8 @@ impl NotificationWorker {
                             "valerter_notify_errors_total",
                             "notifier_name" => dest_name.to_string(),
                             "notifier_type" => "unknown",
-                            "rule_name" => payload.rule_name.clone()
+                            "rule_name" => payload.rule_name.clone(),
+                            "vl_source" => payload.vl_source.clone(),
                         )
                         .increment(1);
                         None

--- a/src/notify/telegram.rs
+++ b/src/notify/telegram.rs
@@ -436,8 +436,9 @@ impl Notifier for TelegramNotifier {
                         metrics::counter!(
                             "valerter_alerts_sent_total",
                             "rule_name" => alert.rule_name.clone(),
+                            "vl_source" => alert.vl_source.clone(),
                             "notifier_name" => self.name.clone(),
-                            "notifier_type" => "telegram"
+                            "notifier_type" => "telegram",
                         )
                         .increment(1);
                     }
@@ -450,15 +451,17 @@ impl Notifier for TelegramNotifier {
                         metrics::counter!(
                             "valerter_notify_errors_total",
                             "rule_name" => alert.rule_name.clone(),
+                            "vl_source" => alert.vl_source.clone(),
                             "notifier_name" => self.name.clone(),
-                            "notifier_type" => "telegram"
+                            "notifier_type" => "telegram",
                         )
                         .increment(1);
                         metrics::counter!(
                             "valerter_alerts_failed_total",
                             "rule_name" => alert.rule_name.clone(),
+                            "vl_source" => alert.vl_source.clone(),
                             "notifier_name" => self.name.clone(),
-                            "notifier_type" => "telegram"
+                            "notifier_type" => "telegram",
                         )
                         .increment(1);
                     }

--- a/src/notify/webhook.rs
+++ b/src/notify/webhook.rs
@@ -281,8 +281,9 @@ impl Notifier for WebhookNotifier {
                         metrics::counter!(
                             "valerter_alerts_sent_total",
                             "rule_name" => alert.rule_name.clone(),
+                            "vl_source" => alert.vl_source.clone(),
                             "notifier_name" => self.name.clone(),
-                            "notifier_type" => "webhook"
+                            "notifier_type" => "webhook",
                         )
                         .increment(1);
                         return Ok(());
@@ -297,16 +298,18 @@ impl Notifier for WebhookNotifier {
                         metrics::counter!(
                             "valerter_notify_errors_total",
                             "rule_name" => alert.rule_name.clone(),
+                            "vl_source" => alert.vl_source.clone(),
                             "notifier_name" => self.name.clone(),
-                            "notifier_type" => "webhook"
+                            "notifier_type" => "webhook",
                         )
                         .increment(1);
                         // Permanent failure - count as failed alert
                         metrics::counter!(
                             "valerter_alerts_failed_total",
                             "rule_name" => alert.rule_name.clone(),
+                            "vl_source" => alert.vl_source.clone(),
                             "notifier_name" => self.name.clone(),
-                            "notifier_type" => "webhook"
+                            "notifier_type" => "webhook",
                         )
                         .increment(1);
                         return Err(NotifyError::SendFailed(format!("client error: {}", status)));
@@ -345,16 +348,18 @@ impl Notifier for WebhookNotifier {
             metrics::counter!(
                 "valerter_notify_errors_total",
                 "rule_name" => alert.rule_name.clone(),
+                "vl_source" => alert.vl_source.clone(),
                 "notifier_name" => self.name.clone(),
-                "notifier_type" => "webhook"
+                "notifier_type" => "webhook",
             )
             .increment(1);
             // Permanent failure after retries exhausted
             metrics::counter!(
                 "valerter_alerts_failed_total",
                 "rule_name" => alert.rule_name.clone(),
+                "vl_source" => alert.vl_source.clone(),
                 "notifier_name" => self.name.clone(),
-                "notifier_type" => "webhook"
+                "notifier_type" => "webhook",
             )
             .increment(1);
             Err(NotifyError::MaxRetriesExceeded)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,30 +26,33 @@ use serde_json::{Map, Value};
 /// Record a successful log match with metrics.
 ///
 /// This function should be called by the pipeline code when parsing succeeds.
-/// It increments the `valerter_logs_matched_total` counter with proper labels.
-/// This metric counts successful matches BEFORE throttling is applied.
+/// It increments the `valerter_logs_matched_total` counter with `rule_name`
+/// and `vl_source` labels. This metric counts successful matches BEFORE
+/// throttling is applied.
 ///
 /// # Arguments
 ///
 /// * `rule_name` - The name of the rule that matched the log
+/// * `vl_source` - The name of the VictoriaLogs source the event came from
 ///
 /// # Example
 ///
 /// ```ignore
 /// match parser.parse(&line) {
 ///     Ok(fields) => {
-///         record_log_matched(&rule.name);
+///         record_log_matched(&rule.name, &vl_source);
 ///         // Continue processing...
 ///     }
 ///     Err(e) => {
-///         record_parse_error(&rule.name, &e);
+///         record_parse_error(&rule.name, &vl_source, &e);
 ///     }
 /// }
 /// ```
-pub fn record_log_matched(rule_name: &str) {
+pub fn record_log_matched(rule_name: &str, vl_source: &str) {
     metrics::counter!(
         "valerter_logs_matched_total",
-        "rule_name" => rule_name.to_string()
+        "rule_name" => rule_name.to_string(),
+        "vl_source" => vl_source.to_string(),
     )
     .increment(1);
 }
@@ -58,11 +61,13 @@ pub fn record_log_matched(rule_name: &str) {
 ///
 /// This function should be called by the pipeline code when parsing fails.
 /// It logs the error at the appropriate level and increments the
-/// `valerter_parse_errors_total` counter with proper labels.
+/// `valerter_parse_errors_total` counter with `rule_name`, `vl_source`, and
+/// `error_type` labels.
 ///
 /// # Arguments
 ///
 /// * `rule_name` - The name of the rule that encountered the error
+/// * `vl_source` - The name of the VictoriaLogs source the event came from
 /// * `error` - The parse error that occurred
 ///
 /// # Example
@@ -71,12 +76,12 @@ pub fn record_log_matched(rule_name: &str) {
 /// match parser.parse(&line) {
 ///     Ok(fields) => { /* process */ }
 ///     Err(e) => {
-///         record_parse_error(&rule.name, &e);
+///         record_parse_error(&rule.name, &vl_source, &e);
 ///         // Skip this log silently (FR20)
 ///     }
 /// }
 /// ```
-pub fn record_parse_error(rule_name: &str, error: &ParseError) {
+pub fn record_parse_error(rule_name: &str, vl_source: &str, error: &ParseError) {
     let error_type = match error {
         ParseError::NoMatch => "regex_no_match",
         ParseError::InvalidJson(_) => "invalid_json",
@@ -88,6 +93,7 @@ pub fn record_parse_error(rule_name: &str, error: &ParseError) {
             // NoMatch is normal behavior - log at DEBUG level
             tracing::debug!(
                 rule_name = %rule_name,
+                vl_source = %vl_source,
                 "Regex did not match, skipping log"
             );
         }
@@ -95,6 +101,7 @@ pub fn record_parse_error(rule_name: &str, error: &ParseError) {
             // Invalid JSON is unexpected - log at WARN level
             tracing::warn!(
                 rule_name = %rule_name,
+                vl_source = %vl_source,
                 error = %msg,
                 "Invalid JSON in log"
             );
@@ -105,7 +112,8 @@ pub fn record_parse_error(rule_name: &str, error: &ParseError) {
     metrics::counter!(
         "valerter_parse_errors_total",
         "rule_name" => rule_name.to_string(),
-        "error_type" => error_type
+        "vl_source" => vl_source.to_string(),
+        "error_type" => error_type,
     )
     .increment(1);
 }
@@ -754,7 +762,7 @@ mod tests {
     fn record_parse_error_no_match_does_not_panic() {
         let error = ParseError::NoMatch;
         // Should not panic
-        super::record_parse_error("test_rule", &error);
+        super::record_parse_error("test_rule", "vlprod", &error);
     }
 
     // Test: record_parse_error does not panic for InvalidJson
@@ -762,22 +770,22 @@ mod tests {
     fn record_parse_error_invalid_json_does_not_panic() {
         let error = ParseError::InvalidJson("unexpected token".to_string());
         // Should not panic
-        super::record_parse_error("test_rule", &error);
+        super::record_parse_error("test_rule", "vlprod", &error);
     }
 
     // Test: record_log_matched does not panic
     #[test]
     fn record_log_matched_does_not_panic() {
         // Should not panic
-        super::record_log_matched("test_rule");
+        super::record_log_matched("test_rule", "vlprod");
     }
 
     // Test: record_log_matched can be called multiple times
     #[test]
     fn record_log_matched_multiple_calls() {
         // Should not panic even with multiple calls
-        super::record_log_matched("rule_a");
-        super::record_log_matched("rule_b");
-        super::record_log_matched("rule_a");
+        super::record_log_matched("rule_a", "vlprod");
+        super::record_log_matched("rule_b", "vldev");
+        super::record_log_matched("rule_a", "vlprod");
     }
 }

--- a/src/tail.rs
+++ b/src/tail.rs
@@ -188,6 +188,7 @@ impl TailClient {
     pub async fn connect_and_receive(
         &mut self,
         rule_name: &str,
+        vl_source: &str,
     ) -> Result<Vec<String>, StreamError> {
         let url = self.build_url();
 
@@ -219,6 +220,7 @@ impl TailClient {
             if let Err(StreamError::LineTooLarge(size, max)) = self.buffer.push(&chunk) {
                 warn!(
                     rule_name = %rule_name,
+                    vl_source = %vl_source,
                     size_bytes = size,
                     max_bytes = max,
                     "Discarding oversized log line, buffer cleared"
@@ -226,7 +228,8 @@ impl TailClient {
                 metrics::counter!(
                     "valerter_lines_discarded_total",
                     "rule_name" => rule_name.to_string(),
-                    "reason" => "oversized"
+                    "vl_source" => vl_source.to_string(),
+                    "reason" => "oversized",
                 )
                 .increment(1);
                 continue;
@@ -235,7 +238,12 @@ impl TailClient {
 
             for line in lines {
                 if !line.is_empty() {
-                    trace!(rule_name = %rule_name, line_len = line.len(), "Received log line");
+                    trace!(
+                        rule_name = %rule_name,
+                        vl_source = %vl_source,
+                        line_len = line.len(),
+                        "Received log line"
+                    );
                     all_lines.push(line);
                 }
             }
@@ -286,6 +294,7 @@ impl TailClient {
     /// // Stream with reconnection - runs until cancelled
     /// client.stream_with_reconnect(
     ///     "my_rule",
+    ///     "vlprod",
     ///     None,
     ///     |line| async move {
     ///         println!("Received: {}", line);
@@ -298,6 +307,7 @@ impl TailClient {
     pub async fn stream_with_reconnect<F, Fut>(
         &mut self,
         rule_name: &str,
+        vl_source: &str,
         on_reconnect: Option<&dyn ReconnectCallback>,
         mut line_handler: F,
     ) -> Result<(), StreamError>
@@ -310,7 +320,12 @@ impl TailClient {
 
         loop {
             let url = self.build_url();
-            debug!(rule_name = %rule_name, url = %url, "Connecting to VictoriaLogs tail endpoint");
+            debug!(
+                rule_name = %rule_name,
+                vl_source = %vl_source,
+                url = %url,
+                "Connecting to VictoriaLogs tail endpoint"
+            );
 
             // Start timing for query_duration metric
             let request_start = Instant::now();
@@ -318,19 +333,26 @@ impl TailClient {
 
             let response = match connect_result {
                 Ok(resp) if resp.status().is_success() => {
-                    info!(rule_name = %rule_name, status = %resp.status(), "Connected to VictoriaLogs");
-                    // Connection successful - mark VictoriaLogs as up
+                    info!(
+                        rule_name = %rule_name,
+                        vl_source = %vl_source,
+                        status = %resp.status(),
+                        "Connected to VictoriaLogs"
+                    );
+                    // Connection successful - mark this source as up
+                    // (per-source gauge replaces the v1.x per-rule
+                    // `valerter_victorialogs_up{rule_name}`).
                     metrics::gauge!(
-                        "valerter_victorialogs_up",
-                        "rule_name" => rule_name.to_string()
+                        "valerter_vl_source_up",
+                        "vl_source" => vl_source.to_string(),
                     )
                     .set(1.0);
 
                     if had_failure {
                         // We recovered from a failure
-                        log_reconnection_success(rule_name);
+                        log_reconnection_success(rule_name, vl_source);
                         if let Some(callback) = on_reconnect {
-                            callback.on_reconnect(rule_name);
+                            callback.on_reconnect(rule_name, vl_source);
                         }
                     }
                     attempt = 0;
@@ -338,39 +360,45 @@ impl TailClient {
                     resp
                 }
                 Ok(resp) => {
-                    // HTTP error (4xx, 5xx) - mark VictoriaLogs as down
+                    // HTTP error (4xx, 5xx) - mark this source as down.
                     metrics::gauge!(
-                        "valerter_victorialogs_up",
-                        "rule_name" => rule_name.to_string()
+                        "valerter_vl_source_up",
+                        "vl_source" => vl_source.to_string(),
                     )
                     .set(0.0);
 
                     had_failure = true;
-                    let delay = backoff_delay_default(attempt);
-                    log_reconnection_attempt(rule_name, attempt, delay);
+                    let delay = backoff_delay_with_jitter(attempt);
+                    log_reconnection_attempt(rule_name, vl_source, attempt, delay);
                     tokio::time::sleep(delay).await;
                     attempt = attempt.saturating_add(1);
                     warn!(
                         rule_name = %rule_name,
+                        vl_source = %vl_source,
                         status = %resp.status(),
                         "HTTP error from VictoriaLogs"
                     );
                     continue;
                 }
                 Err(e) => {
-                    // Connection error - mark VictoriaLogs as down
+                    // Connection error - mark this source as down.
                     metrics::gauge!(
-                        "valerter_victorialogs_up",
-                        "rule_name" => rule_name.to_string()
+                        "valerter_vl_source_up",
+                        "vl_source" => vl_source.to_string(),
                     )
                     .set(0.0);
 
                     had_failure = true;
-                    let delay = backoff_delay_default(attempt);
-                    log_reconnection_attempt(rule_name, attempt, delay);
+                    let delay = backoff_delay_with_jitter(attempt);
+                    log_reconnection_attempt(rule_name, vl_source, attempt, delay);
                     tokio::time::sleep(delay).await;
                     attempt = attempt.saturating_add(1);
-                    warn!(rule_name = %rule_name, error = %e, "Connection failed");
+                    warn!(
+                        rule_name = %rule_name,
+                        vl_source = %vl_source,
+                        error = %e,
+                        "Connection failed"
+                    );
                     continue;
                 }
             };
@@ -388,7 +416,8 @@ impl TailClient {
                             let duration = request_start.elapsed();
                             metrics::histogram!(
                                 "valerter_query_duration_seconds",
-                                "rule_name" => rule_name.to_string()
+                                "rule_name" => rule_name.to_string(),
+                                "vl_source" => vl_source.to_string(),
                             )
                             .record(duration.as_secs_f64());
                         }
@@ -400,7 +429,8 @@ impl TailClient {
                             .as_secs_f64();
                         metrics::gauge!(
                             "valerter_last_query_timestamp",
-                            "rule_name" => rule_name.to_string()
+                            "rule_name" => rule_name.to_string(),
+                            "vl_source" => vl_source.to_string(),
                         )
                         .set(now);
 
@@ -408,6 +438,7 @@ impl TailClient {
                         {
                             warn!(
                                 rule_name = %rule_name,
+                                vl_source = %vl_source,
                                 size_bytes = size,
                                 max_bytes = max,
                                 "Discarding oversized log line, buffer cleared"
@@ -415,7 +446,8 @@ impl TailClient {
                             metrics::counter!(
                                 "valerter_lines_discarded_total",
                                 "rule_name" => rule_name.to_string(),
-                                "reason" => "oversized"
+                                "vl_source" => vl_source.to_string(),
+                                "reason" => "oversized",
                             )
                             .increment(1);
                             continue;
@@ -424,25 +456,35 @@ impl TailClient {
 
                         for line in lines {
                             if !line.is_empty() {
-                                trace!(rule_name = %rule_name, line_len = line.len(), "Received log line");
+                                trace!(
+                                    rule_name = %rule_name,
+                                    vl_source = %vl_source,
+                                    line_len = line.len(),
+                                    "Received log line"
+                                );
                                 line_handler(line).await?;
                             }
                         }
                     }
                     Err(e) => {
-                        // Stream error - mark VictoriaLogs as down and reconnect
+                        // Stream error - mark this source as down and reconnect.
                         metrics::gauge!(
-                            "valerter_victorialogs_up",
-                            "rule_name" => rule_name.to_string()
+                            "valerter_vl_source_up",
+                            "vl_source" => vl_source.to_string(),
                         )
                         .set(0.0);
 
                         had_failure = true;
-                        let delay = backoff_delay_default(attempt);
-                        log_reconnection_attempt(rule_name, attempt, delay);
+                        let delay = backoff_delay_with_jitter(attempt);
+                        log_reconnection_attempt(rule_name, vl_source, attempt, delay);
                         tokio::time::sleep(delay).await;
                         attempt = attempt.saturating_add(1);
-                        warn!(rule_name = %rule_name, error = %e, "Stream read error");
+                        warn!(
+                            rule_name = %rule_name,
+                            vl_source = %vl_source,
+                            error = %e,
+                            "Stream read error"
+                        );
                         break; // Break inner loop to reconnect
                     }
                 }
@@ -451,7 +493,11 @@ impl TailClient {
             // Stream ended (server closed connection) - reconnect
             if !had_failure {
                 // Normal stream end, not a failure - still need to reconnect
-                debug!(rule_name = %rule_name, "Stream ended, reconnecting");
+                debug!(
+                    rule_name = %rule_name,
+                    vl_source = %vl_source,
+                    "Stream ended, reconnecting"
+                );
             }
             had_failure = true;
         }
@@ -480,8 +526,46 @@ pub fn backoff_delay(attempt: u32, base: Duration, max: Duration) -> Duration {
 /// Calculate exponential backoff delay using default VictoriaLogs parameters.
 ///
 /// Uses BACKOFF_BASE (1s) and BACKOFF_MAX (60s) as per AD-07.
-pub fn backoff_delay_default(attempt: u32) -> Duration {
+///
+/// Exposed `pub(crate)` only: production callers must go through
+/// [`backoff_delay_with_jitter`] so the jitter clamp is always applied. Direct
+/// use bypasses that safety net.
+pub(crate) fn backoff_delay_default(attempt: u32) -> Duration {
     backoff_delay(attempt, BACKOFF_BASE, BACKOFF_MAX)
+}
+
+/// Minimum reconnect delay floor in milliseconds (post-jitter clamp).
+///
+/// The exponential backoff base is 1s = 1000ms, so a -10% jitter on attempt
+/// 0 produces 900ms which is well above this floor; the clamp is a defensive
+/// safety net for any future change that lowers `BACKOFF_BASE`.
+pub const MIN_RECONNECT_DELAY_MS: u64 = 100;
+
+/// Compute the backoff delay with `±10%` uniform jitter applied per call.
+///
+/// Multi-source observability (v2.0.0 part 2): when N sources behind a flapping
+/// load balancer all reconnect at the same exponential cadence they form a
+/// thundering herd. Per-task uniform jitter spreads attempts in a `[0.9·D,
+/// 1.1·D]` window so the herd dissolves over a few cycles without changing
+/// the overall reconnect rate.
+///
+/// The jitter is uniform over `[-0.10, +0.10]` (inclusive) and the resulting
+/// delay is clamped to [`MIN_RECONNECT_DELAY_MS`] so a negative jitter never
+/// produces a sub-100ms hot loop.
+pub fn backoff_delay_with_jitter(attempt: u32) -> Duration {
+    use rand::Rng;
+
+    let base = backoff_delay_default(attempt);
+    let jitter: f64 = rand::thread_rng().gen_range(-0.10..=0.10);
+    apply_jitter_floor(base.as_millis() as u64, jitter)
+}
+
+/// Apply a `(1 + jitter)` multiplier to a millisecond base and clamp the
+/// result to [`MIN_RECONNECT_DELAY_MS`]. Pure helper so the clamp branch is
+/// directly exercisable from unit tests with synthetic small bases.
+fn apply_jitter_floor(base_ms: u64, jitter: f64) -> Duration {
+    let effective_ms = ((base_ms as f64) * (1.0 + jitter)).max(MIN_RECONNECT_DELAY_MS as f64);
+    Duration::from_millis(effective_ms as u64)
 }
 
 /// Trait for reconnection callbacks.
@@ -490,7 +574,11 @@ pub fn backoff_delay_default(attempt: u32) -> Duration {
 /// This is used to reset throttle caches as per FR7.
 pub trait ReconnectCallback: Send + Sync {
     /// Called when connection is restored after failure.
-    fn on_reconnect(&self, rule_name: &str);
+    ///
+    /// Receives both the rule name AND the source name so implementors can
+    /// scope their reaction (e.g. throttle reset) per `(rule, source)` task
+    /// rather than fan-out across all sources of the same rule.
+    fn on_reconnect(&self, rule_name: &str, vl_source: &str);
 }
 
 /// Log the reconnection attempt with proper tracing.
@@ -498,19 +586,26 @@ pub trait ReconnectCallback: Send + Sync {
 /// # Arguments
 ///
 /// * `rule_name` - Name of the rule for the tracing span
+/// * `vl_source` - Name of the VictoriaLogs source for the tracing span
 /// * `attempt` - Current retry attempt number
 /// * `delay` - Delay before next retry
-pub fn log_reconnection_attempt(rule_name: &str, attempt: u32, delay: Duration) {
+pub fn log_reconnection_attempt(rule_name: &str, vl_source: &str, attempt: u32, delay: Duration) {
     warn!(
         rule_name = %rule_name,
+        vl_source = %vl_source,
         attempt = attempt,
         delay_secs = delay.as_secs(),
         "Connection failed, retrying"
     );
 
-    // Increment reconnection metric
-    metrics::counter!("valerter_reconnections_total", "rule_name" => rule_name.to_string())
-        .increment(1);
+    // Increment reconnection metric (now per-(rule, source) for multi-source
+    // observability — v2.0.0 part 2).
+    metrics::counter!(
+        "valerter_reconnections_total",
+        "rule_name" => rule_name.to_string(),
+        "vl_source" => vl_source.to_string(),
+    )
+    .increment(1);
 }
 
 /// Log successful reconnection after failure.
@@ -518,9 +613,11 @@ pub fn log_reconnection_attempt(rule_name: &str, attempt: u32, delay: Duration) 
 /// # Arguments
 ///
 /// * `rule_name` - Name of the rule for the tracing span
-pub fn log_reconnection_success(rule_name: &str) {
+/// * `vl_source` - Name of the VictoriaLogs source for the tracing span
+pub fn log_reconnection_success(rule_name: &str, vl_source: &str) {
     info!(
         rule_name = %rule_name,
+        vl_source = %vl_source,
         "Connection restored, throttle cache reset signal sent"
     );
 }
@@ -757,6 +854,81 @@ mod tests {
     fn test_constants_values() {
         assert_eq!(BACKOFF_BASE, Duration::from_secs(1));
         assert_eq!(BACKOFF_MAX, Duration::from_secs(60));
+    }
+
+    // ==========================================================================
+    // Multi-source observability v2.0.0: jitter on reconnect backoff.
+    // The intent is to break thundering-herd alignment on flapping load
+    // balancers; we cannot prove statistical independence in a unit test, but
+    // we can prove the bounds and the floor clamp.
+    // ==========================================================================
+
+    #[test]
+    fn jitter_stays_within_plus_minus_ten_percent_of_base_for_attempt_3() {
+        // Attempt 3 → base 8s = 8000ms. Jittered value must lie in [7200, 8800].
+        let base = backoff_delay_default(3);
+        assert_eq!(base, Duration::from_secs(8));
+        let lo = (base.as_millis() as f64 * 0.90).floor() as u128;
+        let hi = (base.as_millis() as f64 * 1.10).ceil() as u128;
+        for _ in 0..200 {
+            let d = backoff_delay_with_jitter(3);
+            let ms = d.as_millis();
+            assert!(
+                ms >= lo && ms <= hi,
+                "jittered delay {}ms outside [{}, {}]",
+                ms,
+                lo,
+                hi
+            );
+        }
+    }
+
+    #[test]
+    fn jitter_caps_below_min_reconnect_delay_floor() {
+        // Directly exercise the floor branch via the pure helper. With
+        // base_ms=50 and jitter=-0.5, the natural product (25ms) is far
+        // below MIN_RECONNECT_DELAY_MS (100ms) and must be clamped up.
+        let clamped = apply_jitter_floor(50, -0.5);
+        assert_eq!(
+            clamped.as_millis() as u64,
+            MIN_RECONNECT_DELAY_MS,
+            "small base + heavy negative jitter must be clamped to the floor"
+        );
+
+        // Edge: jitter that would land exactly at the floor still pegs to it.
+        let exact = apply_jitter_floor(100, 0.0);
+        assert_eq!(exact.as_millis() as u64, MIN_RECONNECT_DELAY_MS);
+
+        // The default-base path remains unaffected (probabilistic check).
+        for _ in 0..50 {
+            let d = backoff_delay_with_jitter(0);
+            assert!(
+                d.as_millis() >= MIN_RECONNECT_DELAY_MS as u128,
+                "default-base jitter must not drop below floor: {}ms",
+                d.as_millis()
+            );
+        }
+    }
+
+    #[test]
+    fn jitter_at_capped_attempt_stays_within_window_around_max() {
+        // Attempt 100 → backoff is capped to BACKOFF_MAX = 60s.
+        // Jitter window is computed from the cap, not from 2^100.
+        let base = backoff_delay_default(100);
+        assert_eq!(base, BACKOFF_MAX);
+        let lo = (base.as_millis() as f64 * 0.90).floor() as u128;
+        let hi = (base.as_millis() as f64 * 1.10).ceil() as u128;
+        for _ in 0..50 {
+            let d = backoff_delay_with_jitter(100);
+            let ms = d.as_millis();
+            assert!(
+                ms >= lo && ms <= hi,
+                "jittered capped delay {}ms outside [{}, {}]",
+                ms,
+                lo,
+                hi
+            );
+        }
     }
 
     #[test]

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -166,14 +166,18 @@ impl Throttler {
             "Throttle count updated"
         );
 
-        // L1: Pre-convert rule_name to String once for metrics (required for 'static)
+        // L1: Pre-convert rule_name and vl_source to String once for metrics
+        // (required for 'static label storage).
         let rule_name_str = self.rule_name.to_string();
+        let vl_source_str = self.vl_source.to_string();
 
         if count <= self.max_count {
-            // M3: Increment metric for passed alerts
+            // M3: Increment metric for passed alerts (gains `vl_source` for
+            // multi-source observability — v2.0.0 part 2).
             metrics::counter!(
                 "valerter_alerts_passed_total",
-                "rule_name" => rule_name_str
+                "rule_name" => rule_name_str,
+                "vl_source" => vl_source_str,
             )
             .increment(1);
 
@@ -182,16 +186,19 @@ impl Throttler {
             // Log at DEBUG level (throttling is normal behavior)
             tracing::debug!(
                 rule_name = %self.rule_name,
+                vl_source = %self.vl_source,
                 throttle_key = %key,
                 count = count,
                 max_count = self.max_count,
                 "Alert throttled"
             );
 
-            // Increment metric (FR23, FR24)
+            // Increment metric (FR23, FR24); gains `vl_source` to disambiguate
+            // throttle hot-spots per source.
             metrics::counter!(
                 "valerter_alerts_throttled_total",
-                "rule_name" => rule_name_str
+                "rule_name" => rule_name_str,
+                "vl_source" => vl_source_str,
             )
             .increment(1);
 

--- a/tests/integration_streaming.rs
+++ b/tests/integration_streaming.rs
@@ -53,7 +53,10 @@ async fn test_streaming_basic_single_line() {
     let config = create_config(&mock_server, "_stream:test");
     let mut client = TailClient::new(config).unwrap();
 
-    let lines = client.connect_and_receive("test_rule").await.unwrap();
+    let lines = client
+        .connect_and_receive("test_rule", "default")
+        .await
+        .unwrap();
 
     assert_eq!(lines.len(), 1);
     assert!(lines[0].contains("test log"));
@@ -80,7 +83,10 @@ async fn test_streaming_multiple_lines() {
     let config = create_config(&mock_server, "_stream:multi");
     let mut client = TailClient::new(config).unwrap();
 
-    let lines = client.connect_and_receive("test_rule").await.unwrap();
+    let lines = client
+        .connect_and_receive("test_rule", "default")
+        .await
+        .unwrap();
 
     assert_eq!(lines.len(), 3);
     assert!(lines[0].contains("log 1"));
@@ -101,7 +107,10 @@ async fn test_streaming_empty_response() {
     let config = create_config(&mock_server, "_stream:empty");
     let mut client = TailClient::new(config).unwrap();
 
-    let lines = client.connect_and_receive("test_rule").await.unwrap();
+    let lines = client
+        .connect_and_receive("test_rule", "default")
+        .await
+        .unwrap();
 
     assert!(lines.is_empty());
 }
@@ -123,7 +132,7 @@ async fn test_connection_error_http_500() {
     let config = create_config(&mock_server, "_stream:error");
     let mut client = TailClient::new(config).unwrap();
 
-    let result = client.connect_and_receive("test_rule").await;
+    let result = client.connect_and_receive("test_rule", "default").await;
 
     assert!(result.is_err());
     match result {
@@ -147,7 +156,7 @@ async fn test_connection_error_http_404() {
     let config = create_config(&mock_server, "_stream:notfound");
     let mut client = TailClient::new(config).unwrap();
 
-    let result = client.connect_and_receive("test_rule").await;
+    let result = client.connect_and_receive("test_rule", "default").await;
 
     assert!(result.is_err());
     match result {
@@ -171,7 +180,7 @@ async fn test_connection_error_http_503() {
     let config = create_config(&mock_server, "_stream:unavailable");
     let mut client = TailClient::new(config).unwrap();
 
-    let result = client.connect_and_receive("test_rule").await;
+    let result = client.connect_and_receive("test_rule", "default").await;
 
     assert!(result.is_err());
     match result {
@@ -196,7 +205,7 @@ async fn test_connection_error_server_down() {
 
     let mut client = TailClient::new(config).unwrap();
 
-    let result = client.connect_and_receive("test_rule").await;
+    let result = client.connect_and_receive("test_rule", "default").await;
 
     assert!(result.is_err());
     match result {
@@ -231,7 +240,7 @@ async fn test_timeout_detection() {
     let mut client = TailClient::new(config).unwrap();
 
     // This won't actually timeout since delay is short, but tests the path
-    let result = client.connect_and_receive("test_rule").await;
+    let result = client.connect_and_receive("test_rule", "default").await;
 
     // Should succeed (data received before timeout)
     // The buffer will hold "incomplete" without newline
@@ -287,7 +296,7 @@ async fn test_url_construction_is_correct() {
     };
 
     let mut client = TailClient::new(config).unwrap();
-    let _ = client.connect_and_receive("test_rule").await;
+    let _ = client.connect_and_receive("test_rule", "default").await;
 
     // If we get here without panic, the URL matched
 }
@@ -315,7 +324,7 @@ async fn test_url_with_start_param() {
     };
 
     let mut client = TailClient::new(config).unwrap();
-    let _ = client.connect_and_receive("test_rule").await;
+    let _ = client.connect_and_receive("test_rule", "default").await;
 }
 
 // =============================================================================
@@ -338,7 +347,7 @@ async fn test_headers_are_set_correctly() {
     let config = create_config(&mock_server, "_stream:headers");
     let mut client = TailClient::new(config).unwrap();
 
-    let _ = client.connect_and_receive("test_rule").await;
+    let _ = client.connect_and_receive("test_rule", "default").await;
 }
 
 // =============================================================================
@@ -365,7 +374,10 @@ async fn test_streaming_with_utf8_content() {
     let config = create_config(&mock_server, "_stream:utf8");
     let mut client = TailClient::new(config).unwrap();
 
-    let lines = client.connect_and_receive("test_rule").await.unwrap();
+    let lines = client
+        .connect_and_receive("test_rule", "default")
+        .await
+        .unwrap();
 
     assert_eq!(lines.len(), 2);
     assert!(lines[0].contains("Café"));
@@ -395,7 +407,7 @@ impl TestReconnectCallback {
 }
 
 impl ReconnectCallback for TestReconnectCallback {
-    fn on_reconnect(&self, _rule_name: &str) {
+    fn on_reconnect(&self, _rule_name: &str, _vl_source: &str) {
         self.count.fetch_add(1, Ordering::SeqCst);
     }
 }
@@ -423,7 +435,7 @@ async fn test_stream_with_reconnect_receives_lines() {
     // Use tokio::time::timeout to prevent infinite loop
     let result = tokio::time::timeout(Duration::from_millis(500), async {
         client
-            .stream_with_reconnect("test_rule", None, |line| {
+            .stream_with_reconnect("test_rule", "default", None, |line| {
                 let lines = Arc::clone(&lines_clone);
                 async move {
                     lines.lock().unwrap().push(line);
@@ -474,7 +486,7 @@ async fn test_stream_with_reconnect_retries_on_error() {
     // Use short timeout - should get at least one retry and one success
     let _ = tokio::time::timeout(Duration::from_secs(3), async {
         client
-            .stream_with_reconnect("test_rule", Some(&callback), |line| {
+            .stream_with_reconnect("test_rule", "default", Some(&callback), |line| {
                 let lines = Arc::clone(&lines_clone);
                 async move {
                     lines.lock().unwrap().push(line);
@@ -505,15 +517,15 @@ async fn test_stream_with_reconnect_retries_on_error() {
 #[test]
 fn test_log_reconnection_attempt_does_not_panic() {
     // Just verify the function can be called without panic
-    log_reconnection_attempt("test_rule", 0, Duration::from_secs(1));
-    log_reconnection_attempt("test_rule", 5, Duration::from_secs(32));
-    log_reconnection_attempt("test_rule", 10, Duration::from_secs(60));
+    log_reconnection_attempt("test_rule", "default", 0, Duration::from_secs(1));
+    log_reconnection_attempt("test_rule", "default", 5, Duration::from_secs(32));
+    log_reconnection_attempt("test_rule", "default", 10, Duration::from_secs(60));
 }
 
 #[test]
 fn test_log_reconnection_success_does_not_panic() {
     // Just verify the function can be called without panic
-    log_reconnection_success("test_rule");
+    log_reconnection_success("test_rule", "default");
 }
 
 #[test]
@@ -521,10 +533,10 @@ fn test_reconnect_callback_trait() {
     let callback = TestReconnectCallback::new();
     assert_eq!(callback.reconnect_count(), 0);
 
-    callback.on_reconnect("rule1");
+    callback.on_reconnect("rule1", "vlprod");
     assert_eq!(callback.reconnect_count(), 1);
 
-    callback.on_reconnect("rule2");
+    callback.on_reconnect("rule2", "vldev");
     assert_eq!(callback.reconnect_count(), 2);
 }
 
@@ -598,7 +610,10 @@ async fn test_basic_auth_header_is_sent() {
     let config = create_config_with_basic_auth(&mock_server, "testuser", "testpass");
     let mut client = TailClient::new(config).unwrap();
 
-    let lines = client.connect_and_receive("test_rule").await.unwrap();
+    let lines = client
+        .connect_and_receive("test_rule", "default")
+        .await
+        .unwrap();
 
     assert_eq!(lines.len(), 1);
     assert!(lines[0].contains("authenticated"));
@@ -633,7 +648,10 @@ async fn test_custom_headers_are_sent() {
     let config = create_config_with_headers(&mock_server, headers);
     let mut client = TailClient::new(config).unwrap();
 
-    let lines = client.connect_and_receive("test_rule").await.unwrap();
+    let lines = client
+        .connect_and_receive("test_rule", "default")
+        .await
+        .unwrap();
 
     assert_eq!(lines.len(), 1);
     assert!(lines[0].contains("headers received"));
@@ -663,7 +681,10 @@ async fn test_bearer_token_in_header() {
     let config = create_config_with_headers(&mock_server, headers);
     let mut client = TailClient::new(config).unwrap();
 
-    let lines = client.connect_and_receive("test_rule").await.unwrap();
+    let lines = client
+        .connect_and_receive("test_rule", "default")
+        .await
+        .unwrap();
 
     assert_eq!(lines.len(), 1);
     assert!(lines[0].contains("bearer auth ok"));
@@ -706,7 +727,10 @@ async fn test_basic_auth_with_custom_headers_combined() {
 
     let mut client = TailClient::new(config).unwrap();
 
-    let lines = client.connect_and_receive("test_rule").await.unwrap();
+    let lines = client
+        .connect_and_receive("test_rule", "default")
+        .await
+        .unwrap();
 
     assert_eq!(lines.len(), 1);
     assert!(lines[0].contains("combined auth ok"));
@@ -734,7 +758,7 @@ async fn test_basic_auth_401_on_wrong_credentials() {
     let config = create_config_with_basic_auth(&mock_server, "wrong_user", "wrong_pass");
     let mut client = TailClient::new(config).unwrap();
 
-    let result = client.connect_and_receive("test_rule").await;
+    let result = client.connect_and_receive("test_rule", "default").await;
 
     assert!(result.is_err());
     match result {
@@ -763,7 +787,10 @@ async fn test_without_auth_no_authorization_header() {
     let config = create_config(&mock_server, "_stream:noauth");
     let mut client = TailClient::new(config).unwrap();
 
-    let lines = client.connect_and_receive("test_rule").await.unwrap();
+    let lines = client
+        .connect_and_receive("test_rule", "default")
+        .await
+        .unwrap();
 
     assert_eq!(lines.len(), 1);
     assert!(lines[0].contains("no auth"));

--- a/tests/metrics_snapshot.rs
+++ b/tests/metrics_snapshot.rs
@@ -1,0 +1,330 @@
+//! `/metrics` snapshot test for the multi-source observability work
+//! (v2.0.0 part 2).
+//!
+//! Spins up a 2-source 1-rule engine plus the real Prometheus metrics
+//! exporter on an ephemeral port, exercises every per-rule metric path
+//! once (alert sent, alert throttled, parse error, log matched), then
+//! scrapes `/metrics` and asserts the **set of metric names + label keys**
+//! against an inline expected list. Values and timestamps are intentionally
+//! ignored — the test catches accidental metric rename/relabel in future PRs
+//! without coupling to runtime numbers.
+//!
+//! ## Why a separate integration test binary
+//!
+//! `metrics-exporter-prometheus` installs a global recorder via
+//! `PrometheusBuilder::install()`, which can only run once per process. Each
+//! integration test binary gets its own process, so this file owns the
+//! recorder for its run and does not race with `src/metrics.rs` unit tests
+//! or other integration suites.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::Value;
+use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
+use valerter::config::{
+    CompiledParser, CompiledRule, CompiledTemplate, DEFAULT_MAX_STREAMS, DefaultsConfig,
+    JsonParserConfig, MetricsConfig, NotifyConfig, RuntimeConfig, ThrottleConfig, VlSourceConfig,
+};
+use valerter::notify::{AlertPayload, NotificationQueue};
+use valerter::{MetricsServer, RuleEngine};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Re-serialize a JSON value into NDJSON (one event + trailing newline).
+fn ndjson_body(events: &[&Value]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for ev in events {
+        out.extend_from_slice(
+            serde_json::to_vec(ev)
+                .expect("fixture is valid JSON")
+                .as_slice(),
+        );
+        out.push(b'\n');
+    }
+    out
+}
+
+async fn mount_ndjson(server: &MockServer, events: &[&Value]) {
+    Mock::given(method("GET"))
+        .and(path("/select/logsql/tail"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(ndjson_body(events), "application/x-ndjson"),
+        )
+        .mount(server)
+        .await;
+}
+
+fn rule(name: &str, vl_sources: Vec<String>, throttle_count: u32) -> CompiledRule {
+    CompiledRule {
+        name: name.to_string(),
+        enabled: true,
+        query: "_stream:test".to_string(),
+        parser: CompiledParser {
+            regex: None,
+            json: Some(JsonParserConfig {
+                fields: vec!["_msg".to_string()],
+            }),
+        },
+        throttle: Some(valerter::config::CompiledThrottle {
+            key_template: None,
+            count: throttle_count,
+            window: Duration::from_secs(60),
+        }),
+        notify: NotifyConfig {
+            template: "tpl".to_string(),
+            mattermost_channel: None,
+            destinations: vec!["dest".to_string()],
+        },
+        vl_sources,
+    }
+}
+
+fn vl_source(uri: &str) -> VlSourceConfig {
+    VlSourceConfig {
+        url: uri.to_string(),
+        basic_auth: None,
+        headers: None,
+        tls: None,
+    }
+}
+
+fn runtime(sources: BTreeMap<String, VlSourceConfig>, rules: Vec<CompiledRule>) -> RuntimeConfig {
+    let mut templates = std::collections::HashMap::new();
+    templates.insert(
+        "tpl".to_string(),
+        CompiledTemplate {
+            title: "{{ rule_name }}@{{ vl_source }}".to_string(),
+            body: "{{ _msg }}".to_string(),
+            email_body_html: None,
+            accent_color: None,
+        },
+    );
+
+    RuntimeConfig {
+        victorialogs: sources,
+        defaults: DefaultsConfig {
+            throttle: ThrottleConfig {
+                key: None,
+                count: 5,
+                window: Duration::from_secs(60),
+            },
+            timestamp_timezone: "UTC".to_string(),
+            max_streams: DEFAULT_MAX_STREAMS,
+        },
+        templates,
+        rules,
+        metrics: MetricsConfig::default(),
+        notifiers: None,
+        config_dir: std::path::PathBuf::from("."),
+    }
+}
+
+async fn drain(rx: &mut broadcast::Receiver<AlertPayload>, max: usize, deadline: Duration) {
+    let mut got = 0;
+    let _ = tokio::time::timeout(deadline, async {
+        while got < max {
+            match rx.recv().await {
+                Ok(_) => got += 1,
+                Err(_) => break,
+            }
+        }
+    })
+    .await;
+}
+
+/// Parse a Prometheus exposition body and return the set of `name{labelkeys}`
+/// strings. Label *values* and metric *values* are stripped; only the metric
+/// identifier and the **sorted set of label keys** are kept. This is exactly
+/// what we want to catch accidental rename/relabel without coupling to
+/// counter values, timestamps, or how many label-value combinations exist.
+fn extract_name_label_keys(body: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        // Extract name and (optional) labels block. Format: `name{k="v",...} value`
+        // or `name value`.
+        let (head, _) = match line.split_once(' ') {
+            Some(parts) => parts,
+            None => continue,
+        };
+        let (name, label_keys) = if let Some(brace) = head.find('{') {
+            let name = &head[..brace];
+            let labels_str = &head[brace + 1..head.len() - 1];
+            let mut keys: Vec<&str> = labels_str
+                .split(',')
+                .filter_map(|kv| kv.split_once('=').map(|(k, _)| k))
+                .collect();
+            keys.sort();
+            keys.dedup();
+            (name.to_string(), keys.join(","))
+        } else {
+            (head.to_string(), String::new())
+        };
+        if label_keys.is_empty() {
+            out.insert(name);
+        } else {
+            out.insert(format!("{}{{{}}}", name, label_keys));
+        }
+    }
+    out
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn metrics_snapshot_two_sources_one_rule() {
+    // 1) Mock 2 VL sources. Source `vlprod` serves a parseable event so the
+    //    engine drives the throttle + alert path. Source `vldev` serves a
+    //    line that fails JSON parsing, exercising the parse-error path.
+    let vlprod = MockServer::start().await;
+    let vldev = MockServer::start().await;
+
+    let good_event: Value = serde_json::json!({
+        "_time": "2026-04-15T10:00:00Z",
+        "_stream": "{}",
+        "_msg": "ok",
+    });
+    mount_ndjson(&vlprod, &[&good_event, &good_event, &good_event]).await;
+
+    // For vldev, serve raw garbage so the parser increments
+    // `valerter_parse_errors_total{rule_name, vl_source, error_type}`.
+    Mock::given(method("GET"))
+        .and(path("/select/logsql/tail"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(b"this is not json\n".to_vec(), "application/x-ndjson"),
+        )
+        .mount(&vldev)
+        .await;
+
+    let mut sources = BTreeMap::new();
+    sources.insert("vlprod".to_string(), vl_source(&vlprod.uri()));
+    sources.insert("vldev".to_string(), vl_source(&vldev.uri()));
+
+    // Throttle count=1 on the only rule so the second event on `vlprod`
+    // also exercises the throttled path.
+    let rules = vec![rule("snapshot_rule", Vec::new(), 1)];
+    let cfg = runtime(sources, rules);
+
+    // 2) Boot the metrics server on an ephemeral port. The recorder install
+    //    is a one-shot global; subsequent tests in this same binary cannot
+    //    install it again, which is why this file is a dedicated integration
+    //    test.
+    let port = portpicker::pick_unused_port().expect("free port");
+    let cancel = CancellationToken::new();
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+    let metrics_cancel = cancel.clone();
+    let metrics_handle = tokio::spawn(async move {
+        let server = MetricsServer::with_ready_signal(port, ready_tx);
+        let _ = server.run(metrics_cancel).await;
+    });
+    ready_rx.await.expect("metrics server should signal ready");
+
+    // 3) Initialize all known metric series so the snapshot is deterministic
+    //    even before counters tick. Mirrors the call valerter's main does.
+    let rule_source_pairs: Vec<(&str, &str)> =
+        vec![("snapshot_rule", "vlprod"), ("snapshot_rule", "vldev")];
+    let source_names: Vec<&str> = vec!["vlprod", "vldev"];
+    // Pass at least one notifier so the per-notifier sentinel counters
+    // (`alerts_failed_total{notifier}` / `notify_errors_total{notifier}`)
+    // are seeded and the snapshot can assert their presence.
+    let notifier_names: Vec<&str> = vec!["sentinel"];
+    valerter::initialize_metrics(&rule_source_pairs, &source_names, &notifier_names);
+
+    // 4) Run the engine briefly so each metric path fires at least once.
+    let queue = NotificationQueue::new(64);
+    let mut rx = queue.subscribe();
+    let engine = RuleEngine::new(cfg, reqwest::Client::new(), queue.clone());
+    let cancel_for_engine = cancel.clone();
+    let engine_handle = tokio::spawn(async move { engine.run(cancel_for_engine).await });
+
+    // Drain a few alerts to make sure the throttle/passed/sent paths run.
+    drain(&mut rx, 5, Duration::from_secs(2)).await;
+
+    // 5) Scrape /metrics.
+    let url = format!("http://127.0.0.1:{}/metrics", port);
+    let body = reqwest::Client::new()
+        .get(&url)
+        .send()
+        .await
+        .expect("scrape should succeed")
+        .text()
+        .await
+        .expect("body should decode");
+
+    // 6) Tear down. The engine task runs forever until cancelled.
+    cancel.cancel();
+    let _ = tokio::time::timeout(Duration::from_secs(2), engine_handle).await;
+    let _ = tokio::time::timeout(Duration::from_secs(1), metrics_handle).await;
+
+    // 7) Assert the snapshot. We check that *every expected* metric series
+    //    (name + label-key set) is present. The actual output may carry
+    //    additional series from per-(rule, source) initialization that we
+    //    explicitly seeded, so we tolerate supersets.
+    let actual = extract_name_label_keys(&body);
+
+    // Inline expected snapshot. Sorted alphabetically for stable diffs.
+    // Each entry is `metric_name{label_keys_csv_sorted}` or just
+    // `metric_name` when unlabeled.
+    let expected: Arc<[&'static str]> = Arc::from([
+        // Per-(rule, source) counters seeded by initialize_metrics.
+        "valerter_alerts_passed_total{rule_name,vl_source}",
+        "valerter_alerts_sent_total{rule_name,vl_source}",
+        "valerter_alerts_throttled_total{rule_name,vl_source}",
+        "valerter_logs_matched_total{rule_name,vl_source}",
+        "valerter_parse_errors_total{rule_name,vl_source}",
+        "valerter_reconnections_total{rule_name,vl_source}",
+        "valerter_rule_errors_total{rule_name,vl_source}",
+        "valerter_rule_panics_total{rule_name,vl_source}",
+        // Per-(rule, source) discarded counter (3-label, reason="oversized").
+        "valerter_lines_discarded_total{reason,rule_name,vl_source}",
+        // Per-(rule, source) gauge for last query timestamp.
+        "valerter_last_query_timestamp{rule_name,vl_source}",
+        // Per-(rule, source) histogram exported as a Prometheus summary by
+        // metrics-exporter-prometheus: emits the metric with `quantile` label
+        // plus `_sum` and `_count` companion series.
+        "valerter_query_duration_seconds{quantile,rule_name,vl_source}",
+        "valerter_query_duration_seconds_count{rule_name,vl_source}",
+        "valerter_query_duration_seconds_sum{rule_name,vl_source}",
+        // Per-notifier sentinel counters.
+        "valerter_alerts_failed_total{notifier}",
+        "valerter_notify_errors_total{notifier}",
+        // Global / shared counters & gauges.
+        "valerter_alerts_dropped_total",
+        "valerter_queue_size",
+        "valerter_uptime_seconds",
+        // Per-source reachability gauge (replaces the old per-rule
+        // valerter_victorialogs_up).
+        "valerter_vl_source_up{vl_source}",
+        // Build info carries only the version label.
+        "valerter_build_info{version}",
+    ]);
+
+    let mut missing: Vec<String> = Vec::new();
+    for want in expected.iter() {
+        if !actual.contains(*want) {
+            missing.push((*want).to_string());
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "metrics snapshot missing expected series:\n  missing = {:#?}\n\n  actual = {:#?}\n\n  raw body =\n{}",
+        missing,
+        actual,
+        body
+    );
+
+    // Hard regression: the v1.x per-rule gauge MUST be gone in v2.0.0.
+    assert!(
+        !actual
+            .iter()
+            .any(|s| s.starts_with("valerter_victorialogs_up")),
+        "valerter_victorialogs_up must be removed in v2.0.0 (replaced by valerter_vl_source_up). Found in /metrics:\n{}",
+        body
+    );
+}

--- a/tests/multi_source_integration.rs
+++ b/tests/multi_source_integration.rs
@@ -115,6 +115,7 @@ fn runtime(sources: BTreeMap<String, VlSourceConfig>, rules: Vec<CompiledRule>) 
                 window: Duration::from_secs(60),
             },
             timestamp_timezone: "UTC".to_string(),
+            max_streams: valerter::config::DEFAULT_MAX_STREAMS,
         },
         templates,
         rules,


### PR DESCRIPTION
Completes [#34](https://github.com/fxthiry/Valerter/issues/34) — multi-source VictoriaLogs observability + guardrails. Builds on PR #36 (multi-source core). Last PR before the v2.0.0 release tag.

## What ships

- **All per-rule Prometheus counters now also carry a `vl_source` label.** Multi-source operators can attribute every alert, error, throttle hit, and reconnect to a specific source. `valerter_queue_size` (shared, not per-source) keeps unlabeled.
- **`valerter_victorialogs_up{rule_name}` removed and replaced by `valerter_vl_source_up{vl_source}`.** Per-source reachability gauge: 1 on connect success, 0 on permanent failure or stream error. Initialized to 0 for every configured source at startup.
- **`defaults.max_streams: 50`** (configurable). Total streams = sum of `(rule, source)` pairs spawned for enabled rules. Breach fails the config at load with both the actual count and the cap value. `max_streams: 0` is explicitly rejected.
- **±10% uniform jitter on reconnect backoff** per `(rule, source)` task. Sources behind a flapping load balancer no longer reconnect in lock-step.
- **`tests/metrics_snapshot.rs`** integration test that scrapes `/metrics` after a 2-source 1-rule warmup and asserts the set of metric names + label keys against an inline expected list. Catches accidental relabel/rename in future PRs.

## Validation

- [x] `cargo test` — 540+ tests pass (479 lib + integration suite, including new `metrics_snapshot`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo run --bin valerter -- --validate -c config/config.example.yaml` — exit 0
- [x] **Manual live regression**: 2-source config (one remote, one local docker container). Cap rejection verified with `max_streams: 2` override (4 streams required > cap of 2). With `max_streams: 50`: `/metrics` scrape shows `valerter_vl_source_up{vl_source}` for both sources at 1, all 8 per-rule counters carry both `rule_name` and `vl_source` labels, and `valerter_victorialogs_up` series is absent.

## Breaking changes summary (full text in CHANGELOG v2.0.0)

- Every metric currently labeled by `rule_name` now also carries `vl_source` (additive).
- `valerter_victorialogs_up{rule_name}` removed; replaced by `valerter_vl_source_up{vl_source}` (per-source semantics, not per-rule). PromQL migration examples in CHANGELOG.
- `defaults.max_streams` cap introduced (default 50). Configs whose enabled-rule fan-out exceeds the cap fail at load.

## Out of scope (deferred)

- `valerter_active_streams` gauge (mentioned in earlier scoping; not needed for v2.0.0 acceptance, follow-up if requested).
- Configurable jitter range (currently hardcoded ±10%; knob if real ops finds 10% wrong).