### PR TITLE
chore(docs): v2.0.0 doc consolidation, fix stale examples + ship MIGRATION + multi-source sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`valerter_vl_source_up{vl_source}` per-source reachability gauge.** Initialized to 0 for every configured source at startup; engine flips to 1 on tail connect success and back to 0 on permanent failure or stream error. Replaces the v1.x per-rule `valerter_victorialogs_up`.
 - **`±10%` uniform jitter on reconnect backoff** (per `(rule, source)` task). Sources behind a flapping load balancer no longer reconnect in lock-step, breaking the thundering-herd alignment over a few cycles. Hardcoded jitter range; not configurable in this release.
 - **`tests/metrics_snapshot.rs` integration test.** Spins up a 2-source 1-rule engine, scrapes `/metrics`, and asserts the set of metric names + label keys (not values) against an inline expected string. Catches accidental relabel/rename in future PRs.
+- **`examples/multi-source/config.yaml`** reference and top-level **[`MIGRATION.md`](MIGRATION.md)** for v1.x upgraders.
 
 ## [1.2.1] - 2026-04-16
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,214 @@
+# Migration Guide
+
+This guide covers upgrading from Valerter **v1.x** to **v2.0.0**. Follow it section by section. Every breaking change has a before / after snippet you can copy.
+
+If you only need a one-line summary: **the `victorialogs` section is now a map of named sources, every per-rule Prometheus metric gained a `vl_source` label, and `valerter_victorialogs_up` was renamed.**
+
+## 1. Pre-Upgrade Checklist
+
+Walk through this before you flip the binary. Each bullet is a concrete file or query you should touch.
+
+### Configuration
+
+- [ ] Open every `config.yaml`, `rules.d/*.yaml`, and `notifiers.d/*.yaml` you ship.
+- [ ] Find the top-level `victorialogs:` block. If it has a direct `url:` key, you must rewrite it (see Section 2).
+- [ ] Decide on your source name(s). Names must match `^[a-zA-Z0-9_]+$`. If you have only one backend today, pick `default`.
+- [ ] Decide if any rule should pin to a subset of sources via `vl_sources: [name, ...]`. By default, rules fan out across every configured source.
+
+### Prometheus Dashboards
+
+- [ ] Search every Grafana dashboard JSON for `valerter_victorialogs_up`. Every match must move to `valerter_vl_source_up` (see Section 3).
+- [ ] Search for PromQL queries that group by `rule_name` only (e.g. `sum by (rule_name) (valerter_alerts_sent_total)`). They keep working but now silently aggregate across sources. If that is not what you want, add `vl_source` to the `by` clause.
+- [ ] Verify panels on per-source overlays will not collapse if a rule fans out to multiple sources.
+
+### Prometheus Alerts
+
+- [ ] Find every `alert:` rule that referenced `valerter_victorialogs_up{rule_name=...}`. Migrate the label key from `rule_name` to `vl_source` (see Section 3 for examples).
+- [ ] Re-evaluate cardinality. Per-rule alerts now multiply by the number of sources you tail.
+
+### Notifier Output
+
+- [ ] If you parse the Mattermost footer string downstream, expect a 4-segment `valerter | <rule> | <source> | <timestamp>` instead of the 3-segment v1.x format (see Section 4).
+- [ ] If you consume the default webhook payload, expect a new top-level `vl_source` field.
+
+## 2. Config Migration
+
+The `victorialogs` section is now a **map of named sources**. The v1.x single-URL shape is rejected at load with an actionable error.
+
+### Before (v1.x)
+
+```yaml
+victorialogs:
+  url: "http://victorialogs:9428"
+  basic_auth:
+    username: "u"
+    password: "p"
+```
+
+### After (v2.0.0)
+
+```yaml
+victorialogs:
+  default:
+    url: "http://victorialogs:9428"
+    basic_auth:
+      username: "u"
+      password: "p"
+```
+
+The minimum-effort migration is one new key (`default:`) and one extra indent level. Credentials, TLS, and headers move under each source, self-contained.
+
+### Targeting sources per rule
+
+Add `vl_sources: [name, ...]` to a rule to restrict it to a subset of sources. Omit the field to fan out across every configured source:
+
+```yaml
+rules:
+  - name: "prod_only_alert"
+    query: '...'
+    vl_sources: [prod]      # only the `prod` source
+    notify: { template: "...", destinations: ["..."] }
+
+  - name: "all_envs_alert"
+    query: '...'
+    # no vl_sources → fans out across every source
+    notify: { template: "...", destinations: ["..."] }
+```
+
+See [`examples/multi-source/`](examples/multi-source/) for a complete reference with prod + staging.
+
+### Source name format
+
+Source names must match `^[a-zA-Z0-9_]+$`. No dashes, dots, colons, or spaces. The constraint avoids ambiguity in the default throttle key format below. Validation runs at load time.
+
+### Default throttle key change
+
+The default throttle key changed from the literal string `<rule_name>:global` (v1.x) to `<rule_name>-<vl_source>:global` (v2.0.0). These angle-bracket placeholders are descriptive notation, not template syntax. Multi-source deployments get isolated throttle buckets per source automatically. If you want **cross-source dedup** (one bucket shared across sources for the same rule), set `throttle.key` explicitly:
+
+```yaml
+rules:
+  - name: "shared_bucket_alert"
+    throttle:
+      key: "{{ rule_name }}"   # back to v1.x semantics
+    # ...
+```
+
+### `defaults.max_streams` cap
+
+A new cap on total `(rule, source)` pairs spawned, default `50`. Disabled rules do not contribute. Breaching the cap fails the config at load with both the actual count and the cap value. Tune via `defaults.max_streams: <usize>` if you fan out many rules across many sources.
+
+## 3. Prometheus Migration
+
+### Removed: `valerter_victorialogs_up{rule_name}`
+
+This per-rule gauge was replaced by a per-source gauge. Reachability is a property of the **source**, not the rule (every rule that tails the same backend reports the same up/down state).
+
+### Added: `valerter_vl_source_up{vl_source}`
+
+One value per configured source, regardless of how many rules tail it. Initialized to 0 at startup; flipped to 1 on tail connect success and back to 0 on permanent failure or stream error. The label key is `vl_source` (not `rule_name`), and the cardinality drops from `|rules|` to `|sources|`.
+
+#### PromQL migration examples
+
+```promql
+# v1.x (per-rule):     valerter_victorialogs_up{rule_name="nginx-5xx"} == 0
+# v2.0.0 (per-source): valerter_vl_source_up{vl_source="prod"} == 0
+
+# v1.x (any rule down): min(valerter_victorialogs_up) == 0
+# v2.0.0 (any source):  min(valerter_vl_source_up) == 0
+```
+
+### `vl_source` label added to every per-rule metric
+
+Affected counters: `valerter_alerts_sent_total`, `valerter_alerts_throttled_total`, `valerter_alerts_passed_total`, `valerter_alerts_failed_total`, `valerter_email_recipient_errors_total`, `valerter_lines_discarded_total`, `valerter_logs_matched_total`, `valerter_notify_errors_total`, `valerter_parse_errors_total`, `valerter_reconnections_total`, `valerter_rule_panics_total`, `valerter_rule_errors_total`.
+
+Affected gauge / histogram: `valerter_last_query_timestamp`, `valerter_query_duration_seconds`.
+
+Dashboards and alerts that grouped by `rule_name` alone keep working but now get an extra `vl_source` dimension. PromQL using `sum by (rule_name) (...)` still rolls up correctly across sources. `valerter_queue_size` stays unlabeled (the queue is shared, not per-source).
+
+### Per-rule alert example
+
+```yaml
+# v1.x
+- alert: ValerterVictoriaLogsDown
+  expr: valerter_victorialogs_up == 0
+  for: 5m
+
+# v2.0.0
+- alert: ValerterVictoriaLogsSourceDown
+  expr: valerter_vl_source_up == 0
+  for: 5m
+  annotations:
+    summary: "Source {{ $labels.vl_source }} unreachable"
+```
+
+## 4. Notifier Output Changes
+
+### Mattermost footer
+
+The footer now carries 4 segments instead of 3:
+
+```
+v1.x: valerter | <rule> | <timestamp>
+v2.0.0: valerter | <rule> | <source> | <timestamp>
+```
+
+If you parse the footer string downstream, update the split logic.
+
+### Default webhook payload
+
+The default webhook payload (used when `body_template` is omitted) gained a top-level `vl_source` field:
+
+```json
+{
+  "alert_name": "<notifier_name>",
+  "rule_name": "...",
+  "vl_source": "prod",
+  "title": "...",
+  "body": "...",
+  "timestamp": "<ISO8601>",
+  "log_timestamp": "<ISO8601>",
+  "log_timestamp_formatted": "DD/MM/YYYY HH:MM:SS TZ"
+}
+```
+
+### Templates
+
+The `{{ vl_source }}` template variable is available everywhere `{{ rule_name }}` is: layer 1 templates (`title`, `body`, `email_body_html`), `throttle.key`, and notifier-level layer 2 contexts (`subject_template`, `body_template`). Always non-empty, equal to the source name currently processing the event.
+
+If an event field is literally named `vl_source`, the synthetic value wins (matches the `rule_name` collision policy).
+
+## 5. Rollback
+
+If something goes wrong after the upgrade, you can roll back to **v1.2.1** with no state migration required. The Prometheus metric labels are additive at the storage layer, except for the removed `valerter_victorialogs_up` gauge (which simply stops being produced when v2.0.0 runs).
+
+### Debian / Ubuntu
+
+```bash
+# Pin v1.2.1
+curl -LO https://github.com/fxthiry/valerter/releases/download/v1.2.1/valerter_1.2.1_amd64.deb
+sudo dpkg -i valerter_1.2.1_amd64.deb
+sudo systemctl restart valerter
+```
+
+### Static binary
+
+```bash
+curl -LO https://github.com/fxthiry/valerter/releases/download/v1.2.1/valerter-linux-x86_64.tar.gz
+tar -xzf valerter-linux-x86_64.tar.gz
+./valerter --validate -c /etc/valerter/config.yaml
+```
+
+You will need to revert the v2.0.0 config rewrite (the v1.x binary will reject the map shape). Keep a `config.yaml.v1` backup before you upgrade.
+
+### Notes
+
+- No on-disk state to migrate: throttle buckets are in-memory only.
+- Prometheus historical data with the new `vl_source` label remains valid (the label simply becomes empty for older samples in TSDB).
+- The v1.x `valerter_victorialogs_up` time series stops growing under v2.0.0 and resumes under v1.2.1.
+
+## See Also
+
+- [`CHANGELOG.md`](CHANGELOG.md) : full v2.0.0 release notes
+- [`examples/multi-source/`](examples/multi-source/) : complete working multi-source reference
+- [`docs/configuration.md`](docs/configuration.md) : full configuration reference
+- [`docs/metrics.md`](docs/metrics.md) : Prometheus metric catalog

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ See [Cisco Switches example](examples/cisco-switches/) for a complete implementa
 
 ## Features
 
+- **One Valerter for every VictoriaLogs you run.** Tail prod, staging, per-region or per-tenant backends from a single instance; pin rules to a specific source or fan out across all of them, with isolated reconnects, per-source metrics, and a `vl_source` label everywhere
 - **Multi-channel notifications** — Webhook (PagerDuty, Slack, Discord), Email SMTP, Mattermost, Telegram
 - **Full log context** — Alerts include the actual log line and extracted fields
 - **Intelligent throttling** — Avoid alert spam with per-key rate limiting
@@ -93,12 +94,13 @@ Example configuration:
 
 ```yaml
 victorialogs:
-  url: "http://victorialogs:9428"
+  default:
+    url: "http://victorialogs:9428"   # replace with your VictoriaLogs host
 
 notifiers:
   mattermost-ops:
     type: mattermost
-    webhook_url: "https://mattermost.example.com/hooks/your-webhook-id"
+    webhook_url: "https://mattermost.example.com/hooks/your-webhook-id"   # replace with your real webhook
 
 defaults:
   throttle:
@@ -113,7 +115,7 @@ templates:
 
 rules:
   - name: "error_logs"
-    query: '_msg:~"(error|failed|critical)"'
+    query: '_msg:~"(error|failed|critical)"'   # adjust to match the events you care about
     parser:
       regex: '(?P<message>.*)'
     notify:
@@ -121,6 +123,8 @@ rules:
       destinations:
         - "mattermost-ops"
 ```
+
+> **Upgrading from v1.x?** The config schema and Prometheus metrics changed in v2.0.0. See [MIGRATION.md](MIGRATION.md) for the full guide.
 
 ## Documentation
 
@@ -131,6 +135,7 @@ rules:
 - **[Performance](docs/performance.md)** — Benchmarks and capacity planning
 - **[Architecture](docs/architecture.md)** — How Valerter works
 - **[Examples](examples/)** — Real-world configurations
+- **[Multi-source example](examples/multi-source/)** — Tail several VictoriaLogs backends from one Valerter instance
 
 ## Contributing
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,7 +78,8 @@ Minimal configuration:
 
 ```yaml
 victorialogs:
-  url: "http://victorialogs:9428"
+  default:
+    url: "http://victorialogs:9428"
 
 notifiers:
   mattermost-ops:

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,5 +1,12 @@
 # Performance Test Report
 
+> **Note:** Numbers in this page were measured against v1.x (single-source).
+> v2.0.0 introduces per-`(rule, source)` concurrency: the engine spawns one task
+> per pair, capped by `defaults.max_streams` (default 50), with `±10%` jitter on
+> reconnect backoff. Throughput, memory, and reconnect behaviour for multi-source
+> deployments are pending re-measurement. The single-source figures below remain
+> a useful baseline.
+
 **Date:** 2026-01-19
 **Version tested:** valerter 1.0.0-rc.5
 **Load generator:** Rust (`tools/load-generator`)
@@ -208,7 +215,7 @@ Tests that valerter recovers from VictoriaLogs outages.
 
 **Results:**
 - Reconnection attempts: 5 (with exponential backoff)
-- Final state: `valerter_victorialogs_up = 1`
+- Final state: `valerter_victorialogs_up = 1` (v1.x; renamed to `valerter_vl_source_up{vl_source}` in v2.0.0)
 - Auto-reconnect successful
 
 **Verdict:** PASS
@@ -247,7 +254,7 @@ Memory is **always bounded** regardless of load.
 valerter_alerts_sent_total          # Notifications actually delivered
 valerter_alerts_throttled_total     # Logs matched but throttled (expected)
 valerter_alerts_dropped_total       # Queue overflow (should be 0 with throttle)
-valerter_victorialogs_up            # Connection health
+valerter_vl_source_up{vl_source}    # Connection health (per source; v1.x: valerter_victorialogs_up)
 ```
 
 ---
@@ -269,7 +276,7 @@ throttle:
 |--------|----------|-------------------|
 | `valerter_alerts_dropped_total` | 0 | Enable/tighten throttle |
 | `valerter_alerts_throttled_total` | > 0 | Normal, throttle working |
-| `valerter_victorialogs_up` | 1 | Check VL connection |
+| `valerter_vl_source_up` | 1 (per source) | Check VL connection (v1.x: `valerter_victorialogs_up`) |
 
 ### 3. Choose Appropriate Throttle Keys
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,7 @@ Each example demonstrates the same 4-step pattern:
 | Example | Description |
 |---------|-------------|
 | **[Cisco Switches](cisco-switches/)** | BPDU Guard alerts for Cisco IOS/IOS-XE switches |
+| **[Multi-Source](multi-source/)** | Tail several VictoriaLogs backends from one Valerter instance (v2.0.0) |
 
 ## Contributing Examples
 

--- a/examples/cisco-switches/config.yaml
+++ b/examples/cisco-switches/config.yaml
@@ -2,7 +2,8 @@
 # ================================================
 
 victorialogs:
-  url: "http://victorialogs:9428"
+  default:
+    url: "http://victorialogs:9428"
 
 metrics:
   enabled: true

--- a/examples/multi-source/README.md
+++ b/examples/multi-source/README.md
@@ -1,0 +1,45 @@
+# Multi-Source VictoriaLogs Example
+
+Demonstrates the v2.0.0 multi-source feature: a single Valerter instance tails two VictoriaLogs backends (`prod` and `staging`) and routes alerts per source.
+
+## Routing Matrix
+
+The [`config.yaml`](config.yaml) file defines 2 sources and 3 rules covering the three routing patterns:
+
+| Rule                       | `vl_sources`         | Spawns tasks for         | Use case                        |
+| -------------------------- | -------------------- | ------------------------ | ------------------------------- |
+| `prod_critical_errors`     | `[prod]`             | `(rule, prod)`           | Pin a rule to one backend       |
+| `staging_deploy_failures`  | `[staging]`          | `(rule, staging)`        | Pin a rule to another backend   |
+| `auth_failures_all_envs`   | (omitted)            | `(rule, prod)` + `(rule, staging)` | Fan out across every source |
+
+Each `(rule, source)` pair runs as an isolated task with its own throttle bucket (default key: `{rule}-{source}:global`) and per-source reconnect with `±10%` jitter. A flapping `staging` backend does not stop alerts on `prod`.
+
+## Source Name Constraints
+
+Source names must match `^[a-zA-Z0-9_]+$` (alphanumeric or underscore only). No dashes, dots, or colons. The constraint avoids ambiguity in the default throttle key format.
+
+## Stream Cap
+
+`defaults.max_streams` (default 50) caps the total number of `(rule, source)` pairs spawned. Disabled rules do not contribute. Breaching the cap fails the config at load with the actual count and the cap value. Tune the limit if you fan many rules across many sources.
+
+## Run It
+
+```bash
+# Set the basic_auth secrets referenced via ${...} in this example
+export VL_PROD_USER="prod_user"
+export VL_PROD_PASS="prod_password"
+
+# Edit webhook_url in config.yaml to point at your real Mattermost hook
+# (--validate parses webhook_url as a URL, so it must be valid at validate time;
+#  ${WEBHOOK_URL} expansion is fine for runtime but not for `--validate`).
+
+# Validate the config
+valerter --validate -c examples/multi-source/config.yaml
+
+# Run it
+valerter -c examples/multi-source/config.yaml
+```
+
+## Observability
+
+The new `valerter_vl_source_up{vl_source}` gauge reports per-source reachability (initialized to 0, flipped to 1 on tail connect success). All per-rule metrics now also carry a `vl_source` label so dashboards can group or filter by source. See [`MIGRATION.md`](../../MIGRATION.md) for the full Prometheus migration guide.

--- a/examples/multi-source/config.yaml
+++ b/examples/multi-source/config.yaml
@@ -1,0 +1,108 @@
+# Valerter Configuration - Multi-Source VictoriaLogs Example
+# ===========================================================
+#
+# Demonstrates the v2.0.0 multi-source feature: a single valerter instance
+# tails two VictoriaLogs backends (`prod` and `staging`) and routes alerts
+# per source.
+#
+# Three rules cover the routing matrix:
+#   1. `prod_critical_errors` — pinned to `prod` only.
+#   2. `staging_deploy_failures` — pinned to `staging` only.
+#   3. `auth_failures_all_envs` — fan-out across both sources (no `vl_sources`).
+#
+# Each `(rule, source)` pair runs as an isolated task. A flapping `staging`
+# source does not stop alerts on `prod`. Default throttle keys are now
+# `{rule}-{source}:global`, so per-source buckets are isolated automatically.
+#
+# Source names must match `^[a-zA-Z0-9_]+$` (no dashes, dots, or colons).
+#
+# Run locally with:
+#   valerter --validate -c examples/multi-source/config.yaml
+
+victorialogs:
+  prod:
+    url: "https://victorialogs.prod.example.com:9428"
+    basic_auth:
+      username: "${VL_PROD_USER}"
+      password: "${VL_PROD_PASS}"
+    tls:
+      verify: true
+
+  staging:
+    url: "http://victorialogs.staging.internal:9428"
+    # No auth on the internal staging backend.
+
+defaults:
+  throttle:
+    count: 10
+    window: 5m
+  timestamp_timezone: "UTC"
+  # max_streams caps total `(rule, source)` pairs spawned. Default is 50;
+  # tune up if you fan out many rules across many sources.
+  # max_streams: 100
+
+notifiers:
+  mattermost-ops:
+    type: mattermost
+    # Replace with your real webhook. Environment variables (e.g.
+    # `webhook_url: "${WEBHOOK_URL}"`) work too, but `--validate` parses the
+    # raw string as a URL so it must be valid at validate time.
+    webhook_url: "https://mattermost.example.com/hooks/your-webhook-id"
+    username: "Valerter"
+
+templates:
+  default_alert:
+    title: "[{{ vl_source }}] {{ rule_name }}"
+    body: |
+      **Source:** `{{ vl_source }}` | **Rule:** `{{ rule_name }}`
+
+      ```
+      {{ _msg }}
+      ```
+    email_body_html: |
+      <p><strong>Source:</strong> <code>{{ vl_source }}</code></p>
+      <p><strong>Rule:</strong> <code>{{ rule_name }}</code></p>
+      <pre>{{ _msg }}</pre>
+    accent_color: "#3498db"
+
+rules:
+  # ── Rule 1: pinned to prod only ────────────────────────────────────────────
+  - name: prod_critical_errors
+    query: '_stream:{env="prod"} level:critical'
+    parser:
+      regex: '(?P<message>.*)'
+    vl_sources:
+      - prod
+    notify:
+      template: default_alert
+      destinations:
+        - mattermost-ops
+
+  # ── Rule 2: pinned to staging only ─────────────────────────────────────────
+  - name: staging_deploy_failures
+    query: '_stream:{env="staging"} _msg:"deploy failed"'
+    parser:
+      regex: '(?P<message>.*)'
+    vl_sources:
+      - staging
+    notify:
+      template: default_alert
+      destinations:
+        - mattermost-ops
+
+  # ── Rule 3: fan-out across all sources (no vl_sources) ────────────────────
+  # Spawns one task per source: (auth_failures_all_envs, prod) and
+  # (auth_failures_all_envs, staging). Each task carries its own throttle
+  # bucket via the default `{rule}-{source}:global` key.
+  - name: auth_failures_all_envs
+    query: '_msg:"authentication failed"'
+    parser:
+      regex: '(?P<message>.*)'
+    notify:
+      template: default_alert
+      destinations:
+        - mattermost-ops
+
+metrics:
+  enabled: true
+  port: 9090

--- a/tests/integration_validate.rs
+++ b/tests/integration_validate.rs
@@ -277,6 +277,87 @@ fn validate_mattermost_env_var_ignored() {
     );
 }
 
+// Test: shipped config/config.example.yaml passes --validate
+// Locks the canonical example against future schema drift.
+#[test]
+fn shipped_config_example_validates() {
+    ensure_binary_built();
+
+    let config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("config")
+        .join("config.example.yaml");
+
+    let output = Command::new(valerter_binary())
+        .args(["--validate", "-c"])
+        .arg(&config_path)
+        .output()
+        .expect("Failed to run valerter");
+
+    assert!(
+        output.status.success(),
+        "shipped config '{}' must pass --validate (exit 0)\nstdout: {}\nstderr: {}",
+        config_path.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// Test: every shipped examples/<name>/config.yaml passes --validate
+// Iterates so new example folders are picked up automatically.
+// Sets placeholder env vars so examples that reference ${...} secrets validate
+// without hitting the network (--validate does not actually call any backend).
+#[test]
+fn shipped_examples_pass_validate() {
+    ensure_binary_built();
+
+    let examples_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples");
+
+    let entries = std::fs::read_dir(&examples_dir).expect("Failed to read examples/ directory");
+
+    let mut checked = 0usize;
+    for entry in entries {
+        let entry = entry.expect("Failed to read examples/ entry");
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let config_path = path.join("config.yaml");
+        if !config_path.exists() {
+            continue;
+        }
+
+        let output = Command::new(valerter_binary())
+            .args(["--validate", "-c"])
+            .arg(&config_path)
+            // Placeholders for examples that reference ${VAR} secrets.
+            // --validate does not perform any network call, so values can be dummies.
+            .env("WEBHOOK_URL", "https://mattermost.example.com/hooks/dummy")
+            .env("VL_PROD_USER", "dummy_user")
+            .env("VL_PROD_PASS", "dummy_pass")
+            .env("VL_PROD_TOKEN", "dummy_token")
+            .env("SMTP_USER", "dummy_smtp_user")
+            .env("SMTP_PASSWORD", "dummy_smtp_pass")
+            .env("TELEGRAM_BOT_TOKEN", "dummy_bot_token")
+            .output()
+            .expect("Failed to run valerter");
+
+        assert!(
+            output.status.success(),
+            "shipped example '{}' must pass --validate (exit 0)\nstdout: {}\nstderr: {}",
+            config_path.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        checked += 1;
+    }
+
+    assert!(
+        checked >= 1,
+        "expected at least one examples/<name>/config.yaml to validate, found 0 in {}",
+        examples_dir.display()
+    );
+}
+
 // Test: --validate with minimal config (README example) passes
 #[test]
 fn validate_minimal_config_exits_success() {


### PR DESCRIPTION
Closes the documentation gaps that were not addressed during the multi-source feature work, before tagging v2.0.0 final.

## What ships

- **Three stale v1.x example configs** (`README.md` Quick Start, `docs/getting-started.md` minimal, `examples/cisco-switches/config.yaml`) migrated to the v2.0.0 map shape with a `default:` source. They would otherwise have been rejected by `--validate` after a copy-paste.
- **`MIGRATION.md` at repo root**: 5-section guide for v1.x upgraders covering the pre-upgrade checklist, config before/after, Prometheus metric migration with PromQL examples, notifier output format changes (Mattermost footer + default webhook payload), and a rollback path. Linked from `README.md` and `CHANGELOG.md`.
- **`examples/multi-source/`**: complete reference config (2 sources, 3 rules covering pinned single-source + fan-out) plus a `README.md` explaining the routing matrix. Closes the explicit ask from the issue [#34](https://github.com/fxthiry/Valerter/issues/34) reporter.
- **README Features list reworked**: multi-source bullet is now position #1 with an outcome-led wording ("One Valerter for every VictoriaLogs you run"). Blockquote callout right after Quick Start points v1.x upgraders at MIGRATION.md.
- **`docs/performance.md` accuracy banner**: throughput numbers in that page were measured against v1.x (single task per rule); the v2.0.0 N×M task model and `max_streams` cap are now mentioned at the top with a note that re-measurement is pending.
- **Two new integration tests** lock the shipped samples against future drift:
  - `shipped_config_example_validates` runs `--validate` on `config/config.example.yaml`.
  - `shipped_examples_pass_validate` iterates `examples/*/config.yaml` and runs `--validate` on each.

## Validation

- [x] `cargo test` — 551 tests pass (479 lib + 72 integration, +2 new in `integration_validate`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] All three shipped example files: `valerter --validate -c <path>` → exit 0
- [x] Manual: README Quick Start YAML extracted to a temp file, `--validate` → exit 0
- [x] Manual link check: every internal markdown link added (README → MIGRATION, README → examples/multi-source, MIGRATION → CHANGELOG sections) resolves on disk

## Out of scope (deferred to follow-up)

- Tagline reword (e.g. "One alerting control plane for all your VictoriaLogs")
- ASCII / SVG diagram for multi-source routing
- "Concepts" page bridging README and configuration.md
- GHSA filing for the email body_html security advisory
- Snippet harvester test that validates inline ```yaml blocks in `.md` files
- Runtime error message that points users at MIGRATION.md when the legacy `victorialogs.url` shape is detected (code change, separate concern)